### PR TITLE
feat: Day 2 (basic-auth) + base64 converter UX (paste, labels, char count, language switcher, explainer)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://pratiyush.github.io/developer-tools/#/base64-string-converter</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>

--- a/scripts/translations-data.ts
+++ b/scripts/translations-data.ts
@@ -50,6 +50,20 @@ const es: Translations = {
   'error.parse.failed':
     'Eso no parece del todo correcto. Comprueba si hay caracteres sueltos o formato erróneo y vuelve a intentarlo.',
   'error.back.home': '← Volver al inicio',
+  'tools.base64.mode.aria': 'Codificar o decodificar',
+  'tools.base64.mode.encode': 'Codificar',
+  'tools.base64.mode.decode': 'Decodificar',
+  'tools.base64.urlsafe.label': 'Variante URL-safe (-_, sin relleno)',
+  'tools.base64.urlsafe.aria': 'Usar alfabeto base64 URL-safe',
+  'tools.base64.input.label': 'Entrada',
+  'tools.base64.input.aria': 'Entrada del conversor base64',
+  'tools.base64.input.placeholder':
+    'Escribe o pega — UTF-8, emoji, segmentos JWT. Todo se reconvierte sin pérdida.',
+  'tools.base64.output.label': 'Salida',
+  'tools.base64.output.aria': 'Salida del conversor base64',
+  'tools.base64.swap': 'Intercambiar ⇄',
+  'tools.base64.copy': 'Copiar',
+  'tools.base64.lengths': '{in} caracteres entrada · {out} caracteres salida',
 };
 
 const fr: Translations = {
@@ -88,6 +102,20 @@ const fr: Translations = {
   'error.parse.failed':
     'Ça n’a pas l’air tout à fait juste. Vérifiez les caractères en trop ou le mauvais format et réessayez.',
   'error.back.home': '← Retour à l’accueil',
+  'tools.base64.mode.aria': 'Encoder ou décoder',
+  'tools.base64.mode.encode': 'Encoder',
+  'tools.base64.mode.decode': 'Décoder',
+  'tools.base64.urlsafe.label': 'Variante URL-safe (-_, sans padding)',
+  'tools.base64.urlsafe.aria': 'Utiliser l’alphabet base64 URL-safe',
+  'tools.base64.input.label': 'Entrée',
+  'tools.base64.input.aria': 'Entrée du convertisseur base64',
+  'tools.base64.input.placeholder':
+    'Tapez ou collez — UTF-8, emoji, segments JWT. Tout fait l’aller-retour proprement.',
+  'tools.base64.output.label': 'Sortie',
+  'tools.base64.output.aria': 'Sortie du convertisseur base64',
+  'tools.base64.swap': 'Échanger ⇄',
+  'tools.base64.copy': 'Copier',
+  'tools.base64.lengths': '{in} caractères entrée · {out} caractères sortie',
 };
 
 const de: Translations = {
@@ -126,6 +154,20 @@ const de: Translations = {
   'error.parse.failed':
     'Das sieht nicht ganz richtig aus. Prüfe auf fremde Zeichen oder falsches Format und versuch es nochmal.',
   'error.back.home': '← Zurück zur Startseite',
+  'tools.base64.mode.aria': 'Kodieren oder Dekodieren',
+  'tools.base64.mode.encode': 'Kodieren',
+  'tools.base64.mode.decode': 'Dekodieren',
+  'tools.base64.urlsafe.label': 'URL-sichere Variante (-_, ohne Padding)',
+  'tools.base64.urlsafe.aria': 'URL-sicheres base64-Alphabet verwenden',
+  'tools.base64.input.label': 'Eingabe',
+  'tools.base64.input.aria': 'Base64-Konverter-Eingabe',
+  'tools.base64.input.placeholder':
+    'Tippen oder einfügen — UTF-8, Emoji, JWT-Segmente. Alles macht den Roundtrip sauber.',
+  'tools.base64.output.label': 'Ausgabe',
+  'tools.base64.output.aria': 'Base64-Konverter-Ausgabe',
+  'tools.base64.swap': 'Tauschen ⇄',
+  'tools.base64.copy': 'Kopieren',
+  'tools.base64.lengths': '{in} Zeichen Eingabe · {out} Zeichen Ausgabe',
 };
 
 const pt: Translations = {
@@ -164,6 +206,20 @@ const pt: Translations = {
   'error.parse.failed':
     'Isso não parece muito certo. Verifica caracteres soltos ou formato errado e tenta de novo.',
   'error.back.home': '← Voltar ao início',
+  'tools.base64.mode.aria': 'Codificar ou decodificar',
+  'tools.base64.mode.encode': 'Codificar',
+  'tools.base64.mode.decode': 'Decodificar',
+  'tools.base64.urlsafe.label': 'Variante URL-safe (-_, sem padding)',
+  'tools.base64.urlsafe.aria': 'Usar alfabeto base64 URL-safe',
+  'tools.base64.input.label': 'Entrada',
+  'tools.base64.input.aria': 'Entrada do conversor base64',
+  'tools.base64.input.placeholder':
+    'Digite ou cole — UTF-8, emoji, segmentos JWT. Tudo faz round-trip limpo.',
+  'tools.base64.output.label': 'Saída',
+  'tools.base64.output.aria': 'Saída do conversor base64',
+  'tools.base64.swap': 'Trocar ⇄',
+  'tools.base64.copy': 'Copiar',
+  'tools.base64.lengths': '{in} caracteres entrada · {out} caracteres saída',
 };
 
 const it: Translations = {
@@ -202,6 +258,20 @@ const it: Translations = {
   'error.parse.failed':
     'Non sembra del tutto giusto. Controlla caratteri estranei o formato sbagliato e riprova.',
   'error.back.home': '← Torna alla home',
+  'tools.base64.mode.aria': 'Codifica o decodifica',
+  'tools.base64.mode.encode': 'Codifica',
+  'tools.base64.mode.decode': 'Decodifica',
+  'tools.base64.urlsafe.label': 'Variante URL-safe (-_, senza padding)',
+  'tools.base64.urlsafe.aria': 'Usa alfabeto base64 URL-safe',
+  'tools.base64.input.label': 'Input',
+  'tools.base64.input.aria': 'Input del convertitore base64',
+  'tools.base64.input.placeholder':
+    'Scrivi o incolla — UTF-8, emoji, segmenti JWT. Tutto torna integro.',
+  'tools.base64.output.label': 'Output',
+  'tools.base64.output.aria': 'Output del convertitore base64',
+  'tools.base64.swap': 'Scambia ⇄',
+  'tools.base64.copy': 'Copia',
+  'tools.base64.lengths': '{in} caratteri input · {out} caratteri output',
 };
 
 const nl: Translations = {
@@ -240,6 +310,20 @@ const nl: Translations = {
   'error.parse.failed':
     'Dat klopt niet helemaal. Controleer op vreemde tekens of verkeerd formaat en probeer opnieuw.',
   'error.back.home': '← Terug naar home',
+  'tools.base64.mode.aria': 'Coderen of decoderen',
+  'tools.base64.mode.encode': 'Coderen',
+  'tools.base64.mode.decode': 'Decoderen',
+  'tools.base64.urlsafe.label': 'URL-veilige variant (-_, geen padding)',
+  'tools.base64.urlsafe.aria': 'URL-veilig base64-alfabet gebruiken',
+  'tools.base64.input.label': 'Invoer',
+  'tools.base64.input.aria': 'Base64-converter-invoer',
+  'tools.base64.input.placeholder':
+    'Typ of plak — UTF-8, emoji, JWT-segmenten. Alles maakt schoon de round-trip.',
+  'tools.base64.output.label': 'Uitvoer',
+  'tools.base64.output.aria': 'Base64-converter-uitvoer',
+  'tools.base64.swap': 'Wisselen ⇄',
+  'tools.base64.copy': 'Kopiëren',
+  'tools.base64.lengths': '{in} tekens invoer · {out} tekens uitvoer',
 };
 
 const pl: Translations = {
@@ -278,6 +362,20 @@ const pl: Translations = {
   'error.parse.failed':
     'To nie wygląda zbyt prawidłowo. Sprawdź zbędne znaki lub zły format i spróbuj ponownie.',
   'error.back.home': '← Wróć do strony głównej',
+  'tools.base64.mode.aria': 'Koduj lub dekoduj',
+  'tools.base64.mode.encode': 'Koduj',
+  'tools.base64.mode.decode': 'Dekoduj',
+  'tools.base64.urlsafe.label': 'Wariant URL-safe (-_, bez paddingu)',
+  'tools.base64.urlsafe.aria': 'Użyj alfabetu base64 URL-safe',
+  'tools.base64.input.label': 'Wejście',
+  'tools.base64.input.aria': 'Wejście konwertera base64',
+  'tools.base64.input.placeholder':
+    'Wpisz lub wklej — UTF-8, emoji, segmenty JWT. Wszystko czysto wraca w obie strony.',
+  'tools.base64.output.label': 'Wyjście',
+  'tools.base64.output.aria': 'Wyjście konwertera base64',
+  'tools.base64.swap': 'Zamień ⇄',
+  'tools.base64.copy': 'Kopiuj',
+  'tools.base64.lengths': '{in} znaków wejście · {out} znaków wyjście',
 };
 
 const ru: Translations = {
@@ -316,6 +414,20 @@ const ru: Translations = {
   'error.parse.failed':
     'Это выглядит не совсем правильно. Проверьте лишние символы или неверный формат и попробуйте снова.',
   'error.back.home': '← Вернуться на главную',
+  'tools.base64.mode.aria': 'Кодировать или декодировать',
+  'tools.base64.mode.encode': 'Кодировать',
+  'tools.base64.mode.decode': 'Декодировать',
+  'tools.base64.urlsafe.label': 'URL-безопасный вариант (-_, без padding)',
+  'tools.base64.urlsafe.aria': 'Использовать URL-безопасный алфавит base64',
+  'tools.base64.input.label': 'Ввод',
+  'tools.base64.input.aria': 'Ввод конвертера base64',
+  'tools.base64.input.placeholder':
+    'Введите или вставьте — UTF-8, эмодзи, сегменты JWT. Всё чисто проходит туда и обратно.',
+  'tools.base64.output.label': 'Вывод',
+  'tools.base64.output.aria': 'Вывод конвертера base64',
+  'tools.base64.swap': 'Поменять ⇄',
+  'tools.base64.copy': 'Копировать',
+  'tools.base64.lengths': '{in} символов ввод · {out} символов вывод',
 };
 
 const tr: Translations = {
@@ -354,6 +466,20 @@ const tr: Translations = {
   'error.parse.failed':
     'Bu pek doğru görünmüyor. Garip karakter veya yanlış biçim var mı bak, yeniden dene.',
   'error.back.home': '← Ana sayfaya dön',
+  'tools.base64.mode.aria': 'Kodla veya çöz',
+  'tools.base64.mode.encode': 'Kodla',
+  'tools.base64.mode.decode': 'Çöz',
+  'tools.base64.urlsafe.label': 'URL-güvenli varyant (-_, padding yok)',
+  'tools.base64.urlsafe.aria': 'URL-güvenli base64 alfabesini kullan',
+  'tools.base64.input.label': 'Girdi',
+  'tools.base64.input.aria': 'Base64 dönüştürücü girdi',
+  'tools.base64.input.placeholder':
+    'Yaz veya yapıştır — UTF-8, emoji, JWT segmentleri. Hepsi temiz şekilde gidip geliyor.',
+  'tools.base64.output.label': 'Çıktı',
+  'tools.base64.output.aria': 'Base64 dönüştürücü çıktı',
+  'tools.base64.swap': 'Değiştir ⇄',
+  'tools.base64.copy': 'Kopyala',
+  'tools.base64.lengths': '{in} karakter girdi · {out} karakter çıktı',
 };
 
 const ja: Translations = {
@@ -392,6 +518,20 @@ const ja: Translations = {
   'error.parse.failed':
     '何かが違うようです。余分な文字や形式の誤りがないか確認して、もう一度試してください。',
   'error.back.home': '← ホームに戻る',
+  'tools.base64.mode.aria': 'エンコードまたはデコード',
+  'tools.base64.mode.encode': 'エンコード',
+  'tools.base64.mode.decode': 'デコード',
+  'tools.base64.urlsafe.label': 'URL安全バリアント (-_, パディングなし)',
+  'tools.base64.urlsafe.aria': 'URL安全な base64 アルファベットを使用',
+  'tools.base64.input.label': '入力',
+  'tools.base64.input.aria': 'Base64 コンバータ入力',
+  'tools.base64.input.placeholder':
+    '入力または貼り付け — UTF-8、絵文字、JWT セグメント。すべてクリーンに往復します。',
+  'tools.base64.output.label': '出力',
+  'tools.base64.output.aria': 'Base64 コンバータ出力',
+  'tools.base64.swap': '入れ替え ⇄',
+  'tools.base64.copy': 'コピー',
+  'tools.base64.lengths': '入力 {in} 文字 · 出力 {out} 文字',
 };
 
 const zh: Translations = {
@@ -427,6 +567,19 @@ const zh: Translations = {
   'error.copy.failed': '剪贴板拒绝了。八成是权限问题 — 检查一下浏览器设置，再试一次。',
   'error.parse.failed': '看起来不太对。检查一下多余的字符或错误格式，再试一次。',
   'error.back.home': '← 返回主页',
+  'tools.base64.mode.aria': '编码或解码',
+  'tools.base64.mode.encode': '编码',
+  'tools.base64.mode.decode': '解码',
+  'tools.base64.urlsafe.label': 'URL 安全变体 (-_, 无填充)',
+  'tools.base64.urlsafe.aria': '使用 URL 安全的 base64 字母表',
+  'tools.base64.input.label': '输入',
+  'tools.base64.input.aria': 'Base64 转换器输入',
+  'tools.base64.input.placeholder': '输入或粘贴 — UTF-8、表情符号、JWT 段。全都干净地往返。',
+  'tools.base64.output.label': '输出',
+  'tools.base64.output.aria': 'Base64 转换器输出',
+  'tools.base64.swap': '交换 ⇄',
+  'tools.base64.copy': '复制',
+  'tools.base64.lengths': '输入 {in} 字符 · 输出 {out} 字符',
 };
 
 const ko: Translations = {
@@ -464,6 +617,20 @@ const ko: Translations = {
   'error.parse.failed':
     '뭔가 어긋난 것 같습니다. 이상한 문자나 잘못된 형식을 확인하고 다시 시도하세요.',
   'error.back.home': '← 홈으로 돌아가기',
+  'tools.base64.mode.aria': '인코딩 또는 디코딩',
+  'tools.base64.mode.encode': '인코딩',
+  'tools.base64.mode.decode': '디코딩',
+  'tools.base64.urlsafe.label': 'URL 안전 변형 (-_, 패딩 없음)',
+  'tools.base64.urlsafe.aria': 'URL 안전 base64 알파벳 사용',
+  'tools.base64.input.label': '입력',
+  'tools.base64.input.aria': 'Base64 변환기 입력',
+  'tools.base64.input.placeholder':
+    '입력하거나 붙여넣으세요 — UTF-8, 이모지, JWT 세그먼트. 모두 깔끔하게 왕복합니다.',
+  'tools.base64.output.label': '출력',
+  'tools.base64.output.aria': 'Base64 변환기 출력',
+  'tools.base64.swap': '교환 ⇄',
+  'tools.base64.copy': '복사',
+  'tools.base64.lengths': '입력 {in}자 · 출력 {out}자',
 };
 
 const hi: Translations = {
@@ -502,6 +669,20 @@ const hi: Translations = {
   'error.parse.failed':
     'यह पूरी तरह सही नहीं लग रहा। फालतू वर्ण या गलत फॉर्मेट देखें और फिर कोशिश करें।',
   'error.back.home': '← होम पर वापस',
+  'tools.base64.mode.aria': 'एनकोड या डीकोड',
+  'tools.base64.mode.encode': 'एनकोड',
+  'tools.base64.mode.decode': 'डीकोड',
+  'tools.base64.urlsafe.label': 'URL-सुरक्षित प्रकार (-_, बिना पैडिंग)',
+  'tools.base64.urlsafe.aria': 'URL-सुरक्षित base64 वर्णमाला का उपयोग करें',
+  'tools.base64.input.label': 'इनपुट',
+  'tools.base64.input.aria': 'Base64 कनवर्टर इनपुट',
+  'tools.base64.input.placeholder':
+    'टाइप करें या पेस्ट करें — UTF-8, इमोजी, JWT सेगमेंट। सब साफ-सुथरे राउंड-ट्रिप करते हैं।',
+  'tools.base64.output.label': 'आउटपुट',
+  'tools.base64.output.aria': 'Base64 कनवर्टर आउटपुट',
+  'tools.base64.swap': 'स्वैप ⇄',
+  'tools.base64.copy': 'कॉपी',
+  'tools.base64.lengths': 'इनपुट {in} वर्ण · आउटपुट {out} वर्ण',
 };
 
 const ar: Translations = {
@@ -538,6 +719,20 @@ const ar: Translations = {
     'الحافظة رفضت. على الأرجح مسألة أذونات — تحقق من إعدادات المتصفح وحاول مرة أخرى.',
   'error.parse.failed': 'هذا لا يبدو صحيحًا تمامًا. تحقق من حروف زائدة أو تنسيق خاطئ وحاول مجددًا.',
   'error.back.home': '← العودة إلى الرئيسية',
+  'tools.base64.mode.aria': 'ترميز أو فك ترميز',
+  'tools.base64.mode.encode': 'ترميز',
+  'tools.base64.mode.decode': 'فك ترميز',
+  'tools.base64.urlsafe.label': 'المتغير الآمن للروابط (-_، بدون حشو)',
+  'tools.base64.urlsafe.aria': 'استخدم الأبجدية base64 الآمنة للروابط',
+  'tools.base64.input.label': 'الإدخال',
+  'tools.base64.input.aria': 'إدخال محول base64',
+  'tools.base64.input.placeholder':
+    'اكتب أو الصق — UTF-8، الإيموجي، أجزاء JWT. كلها تذهب وتعود نظيفة.',
+  'tools.base64.output.label': 'الإخراج',
+  'tools.base64.output.aria': 'إخراج محول base64',
+  'tools.base64.swap': 'تبديل ⇄',
+  'tools.base64.copy': 'نسخ',
+  'tools.base64.lengths': '{in} حرف إدخال · {out} حرف إخراج',
 };
 
 export const ALL_TRANSLATIONS: Record<string, Translations> = {

--- a/scripts/translations-data.ts
+++ b/scripts/translations-data.ts
@@ -33,6 +33,8 @@ const es: Translations = {
   'sidebar.foot.line2': 'Hecho por Pratiyush.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'Repositorio de GitHub',
+  'topbar.language.aria': 'Idioma',
+  'topbar.language.label': 'Idioma',
   'tool.placeholder.title': 'Herramienta aún no implementada',
   'tool.placeholder.body': 'Lógica de la herramienta disponible; capa de renderizado pendiente.',
   'footer.privacy': 'Privacidad',
@@ -47,6 +49,8 @@ const es: Translations = {
     'Algo se rompió. La causa no está del todo clara, ni siquiera para nosotros. Recargar suele ayudar.',
   'error.copy.failed':
     'El portapapeles dijo no. Probablemente sea cuestión de permisos — revisa la configuración de tu navegador y prueba otra vez.',
+  'error.paste.failed':
+    'El portapapeles guardó silencio. Los navegadores piden permiso para pegar — concédelo, o pega con ⌘/Ctrl-V en el campo.',
   'error.parse.failed':
     'Eso no parece del todo correcto. Comprueba si hay caracteres sueltos o formato erróneo y vuelve a intentarlo.',
   'error.back.home': '← Volver al inicio',
@@ -55,15 +59,55 @@ const es: Translations = {
   'tools.base64.mode.decode': 'Decodificar',
   'tools.base64.urlsafe.label': 'Variante URL-safe (-_, sin relleno)',
   'tools.base64.urlsafe.aria': 'Usar alfabeto base64 URL-safe',
-  'tools.base64.input.label': 'Entrada',
-  'tools.base64.input.aria': 'Entrada del conversor base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Texto',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Entrada del conversor base64',
+  'tools.base64.result.aria': 'Salida del conversor base64',
+  'tools.base64.placeholder.encode':
     'Escribe o pega — UTF-8, emoji, segmentos JWT. Todo se reconvierte sin pérdida.',
-  'tools.base64.output.label': 'Salida',
-  'tools.base64.output.aria': 'Salida del conversor base64',
+  'tools.base64.placeholder.decode':
+    'Pega una cadena base64 — segmentos JWT y variantes URL-safe se decodifican igual.',
   'tools.base64.swap': 'Intercambiar ⇄',
   'tools.base64.copy': 'Copiar',
+  'tools.base64.copied': 'Copiado',
+  'tools.base64.paste': 'Pegar',
+  'tools.base64.paste.aria': 'Pegar desde el portapapeles',
+  'tools.base64.pasted': 'Pegado',
+  'tools.base64.chars': '{n} caracteres',
   'tools.base64.lengths': '{in} caracteres entrada · {out} caracteres salida',
+  'tools.base64.explainer.heading': 'Cómo funciona Base64',
+  'tools.base64.explainer.intro':
+    'Base64 empaqueta bytes arbitrarios en 64 caracteres ASCII imprimibles (A–Z, a–z, 0–9, + /). Existe para que los binarios sobrevivan canales de solo texto: campos JSON, URLs, cuerpos de correo y cabeceras HTTP.',
+  'tools.base64.explainer.mechanic':
+    'Toma 3 bytes (24 bits), parte en 4 grupos de 6 bits, busca cada grupo en el alfabeto y emite 4 caracteres ASCII. El `=` final completa la salida a un múltiplo de 4 cuando la entrada no encaja.',
+  'tools.base64.explainer.example.label': 'Ejemplo guiado — codificar "Cat"',
+  'tools.base64.explainer.uses':
+    'Lo verás en HTTP Basic Auth (`Authorization: Basic …`), segmentos de JWT, URIs `data:` en CSS/HTML y adjuntos de correo (MIME).',
+  'tools.base64.explainer.warning':
+    'No es cifrado. Cualquiera con la cadena codificada puede decodificarla. Trata base64 como un sobre de transporte, nunca como un secreto.',
+  'tools.base64.explainer.tryauth': 'Prueba el ayudante de Basic Auth →',
+  'tools.basicauth.mode.aria': 'Construir o leer cabecera',
+  'tools.basicauth.mode.encode': 'Construir',
+  'tools.basicauth.mode.decode': 'Leer',
+  'tools.basicauth.username.label': 'Usuario',
+  'tools.basicauth.username.aria': 'Usuario para Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Contraseña',
+  'tools.basicauth.password.aria': 'Contraseña para Basic auth',
+  'tools.basicauth.password.placeholder': 'ábrete sésamo',
+  'tools.basicauth.password.show': 'Mostrar',
+  'tools.basicauth.password.hide': 'Ocultar',
+  'tools.basicauth.header.label': 'Cabecera Authorization',
+  'tools.basicauth.header.aria': 'Valor de la cabecera HTTP Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Copiar cabecera',
+  'tools.basicauth.copy.username': 'Copiar usuario',
+  'tools.basicauth.copy.password': 'Copiar contraseña',
+  'tools.basicauth.paste.header': 'Pegar cabecera',
+  'tools.basicauth.invalid':
+    'Esa cabecera no se pudo leer. Asegúrate de que tenga la forma `Basic <base64>` y de que el contenido decodificado contenga `:` entre usuario y contraseña.',
+  'tools.basicauth.intro':
+    'Construye y lee la cabecera `Authorization: Basic <base64>` que usa la autenticación HTTP Basic. Todo en local — las credenciales nunca salen de tu navegador.',
 };
 
 const fr: Translations = {
@@ -85,6 +129,8 @@ const fr: Translations = {
   'sidebar.foot.line2': 'Réalisé par Pratiyush.',
   'topbar.theme.aria': 'Thème',
   'topbar.github.aria': 'Dépôt GitHub',
+  'topbar.language.aria': 'Langue',
+  'topbar.language.label': 'Langue',
   'tool.placeholder.title': 'Outil non encore implémenté',
   'tool.placeholder.body': 'Logique de l’outil disponible ; couche de rendu en attente.',
   'footer.privacy': 'Confidentialité',
@@ -99,6 +145,8 @@ const fr: Translations = {
     'Quelque chose a cassé. La cause n’est pas tout à fait claire, même pour nous. Recharger aide souvent.',
   'error.copy.failed':
     'Le presse-papiers a refusé. Sans doute une histoire de permissions — vérifiez votre navigateur et réessayez.',
+  'error.paste.failed':
+    'Le presse-papiers est resté muet. Les navigateurs gèrent le coller derrière une permission — accordez-la, ou collez avec ⌘/Ctrl-V dans le champ.',
   'error.parse.failed':
     'Ça n’a pas l’air tout à fait juste. Vérifiez les caractères en trop ou le mauvais format et réessayez.',
   'error.back.home': '← Retour à l’accueil',
@@ -107,15 +155,55 @@ const fr: Translations = {
   'tools.base64.mode.decode': 'Décoder',
   'tools.base64.urlsafe.label': 'Variante URL-safe (-_, sans padding)',
   'tools.base64.urlsafe.aria': 'Utiliser l’alphabet base64 URL-safe',
-  'tools.base64.input.label': 'Entrée',
-  'tools.base64.input.aria': 'Entrée du convertisseur base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Texte',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Entrée du convertisseur base64',
+  'tools.base64.result.aria': 'Sortie du convertisseur base64',
+  'tools.base64.placeholder.encode':
     'Tapez ou collez — UTF-8, emoji, segments JWT. Tout fait l’aller-retour proprement.',
-  'tools.base64.output.label': 'Sortie',
-  'tools.base64.output.aria': 'Sortie du convertisseur base64',
+  'tools.base64.placeholder.decode':
+    'Collez une chaîne base64 — les segments JWT et les variantes URL-safe se décodent aussi.',
   'tools.base64.swap': 'Échanger ⇄',
   'tools.base64.copy': 'Copier',
+  'tools.base64.copied': 'Copié',
+  'tools.base64.paste': 'Coller',
+  'tools.base64.paste.aria': 'Coller depuis le presse-papiers',
+  'tools.base64.pasted': 'Collé',
+  'tools.base64.chars': '{n} caractères',
   'tools.base64.lengths': '{in} caractères entrée · {out} caractères sortie',
+  'tools.base64.explainer.heading': 'Comment fonctionne Base64',
+  'tools.base64.explainer.intro':
+    'Base64 empaquette des octets arbitraires dans 64 caractères ASCII imprimables (A–Z, a–z, 0–9, + /). Il existe pour que les binaires survivent à des canaux purement texte : champs JSON, URLs, corps de mail, en-têtes HTTP.',
+  'tools.base64.explainer.mechanic':
+    'Prends 3 octets (24 bits), découpe en 4 groupes de 6 bits, cherche chaque groupe dans l’alphabet et émets 4 caractères ASCII. Le `=` final complète la sortie à un multiple de 4 quand l’entrée ne tombe pas juste.',
+  'tools.base64.explainer.example.label': 'Exemple détaillé — encoder « Cat »',
+  'tools.base64.explainer.uses':
+    'On le retrouve dans HTTP Basic Auth (`Authorization: Basic …`), les segments JWT, les URIs `data:` en CSS/HTML, et les pièces jointes mail (MIME).',
+  'tools.base64.explainer.warning':
+    'Ce n’est pas du chiffrement. Quiconque a la chaîne encodée peut la décoder. Considère base64 comme une enveloppe de transport, jamais comme un secret.',
+  'tools.base64.explainer.tryauth': 'Essayer l’aide Basic Auth →',
+  'tools.basicauth.mode.aria': 'Construire ou lire l’en-tête',
+  'tools.basicauth.mode.encode': 'Construire',
+  'tools.basicauth.mode.decode': 'Lire',
+  'tools.basicauth.username.label': 'Identifiant',
+  'tools.basicauth.username.aria': 'Identifiant pour Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Mot de passe',
+  'tools.basicauth.password.aria': 'Mot de passe pour Basic auth',
+  'tools.basicauth.password.placeholder': 'sésame ouvre-toi',
+  'tools.basicauth.password.show': 'Afficher',
+  'tools.basicauth.password.hide': 'Masquer',
+  'tools.basicauth.header.label': 'En-tête Authorization',
+  'tools.basicauth.header.aria': 'Valeur de l’en-tête HTTP Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Copier l’en-tête',
+  'tools.basicauth.copy.username': 'Copier l’identifiant',
+  'tools.basicauth.copy.password': 'Copier le mot de passe',
+  'tools.basicauth.paste.header': 'Coller l’en-tête',
+  'tools.basicauth.invalid':
+    'Cet en-tête n’a pas pu être lu. Vérifie qu’il a la forme `Basic <base64>` et que la charge décodée contient un `:` entre identifiant et mot de passe.',
+  'tools.basicauth.intro':
+    'Construit et lit l’en-tête `Authorization: Basic <base64>` utilisé par l’authentification HTTP Basic. Tout en local — les identifiants ne quittent jamais ton navigateur.',
 };
 
 const de: Translations = {
@@ -137,6 +225,8 @@ const de: Translations = {
   'sidebar.foot.line2': 'Erstellt von Pratiyush.',
   'topbar.theme.aria': 'Thema',
   'topbar.github.aria': 'GitHub-Repository',
+  'topbar.language.aria': 'Sprache',
+  'topbar.language.label': 'Sprache',
   'tool.placeholder.title': 'Tool noch nicht implementiert',
   'tool.placeholder.body': 'Tool-Logik verfügbar; Render-Schicht ausstehend.',
   'footer.privacy': 'Datenschutz',
@@ -151,6 +241,8 @@ const de: Translations = {
     'Etwas ist kaputtgegangen. Die Ursache ist uns selbst nicht ganz klar. Neu laden hilft meist.',
   'error.copy.failed':
     'Die Zwischenablage hat Nein gesagt. Wahrscheinlich Berechtigungen — schau im Browser nach und versuch es noch einmal.',
+  'error.paste.failed':
+    'Die Zwischenablage hat geschwiegen. Browser sperren das Einfügen hinter einer Berechtigung — erteile sie, oder füge mit ⌘/Strg-V direkt ein.',
   'error.parse.failed':
     'Das sieht nicht ganz richtig aus. Prüfe auf fremde Zeichen oder falsches Format und versuch es nochmal.',
   'error.back.home': '← Zurück zur Startseite',
@@ -159,15 +251,55 @@ const de: Translations = {
   'tools.base64.mode.decode': 'Dekodieren',
   'tools.base64.urlsafe.label': 'URL-sichere Variante (-_, ohne Padding)',
   'tools.base64.urlsafe.aria': 'URL-sicheres base64-Alphabet verwenden',
-  'tools.base64.input.label': 'Eingabe',
-  'tools.base64.input.aria': 'Base64-Konverter-Eingabe',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Text',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64-Konverter-Eingabe',
+  'tools.base64.result.aria': 'Base64-Konverter-Ausgabe',
+  'tools.base64.placeholder.encode':
     'Tippen oder einfügen — UTF-8, Emoji, JWT-Segmente. Alles macht den Roundtrip sauber.',
-  'tools.base64.output.label': 'Ausgabe',
-  'tools.base64.output.aria': 'Base64-Konverter-Ausgabe',
+  'tools.base64.placeholder.decode':
+    'Einen base64-String einfügen — JWT-Segmente und URL-sichere Varianten werden ebenso dekodiert.',
   'tools.base64.swap': 'Tauschen ⇄',
   'tools.base64.copy': 'Kopieren',
+  'tools.base64.copied': 'Kopiert',
+  'tools.base64.paste': 'Einfügen',
+  'tools.base64.paste.aria': 'Aus Zwischenablage einfügen',
+  'tools.base64.pasted': 'Eingefügt',
+  'tools.base64.chars': '{n} Zeichen',
   'tools.base64.lengths': '{in} Zeichen Eingabe · {out} Zeichen Ausgabe',
+  'tools.base64.explainer.heading': 'So funktioniert Base64',
+  'tools.base64.explainer.intro':
+    'Base64 packt beliebige Bytes in 64 druckbare ASCII-Zeichen (A–Z, a–z, 0–9, + /). Es existiert, damit Binärdaten reine Textkanäle überleben: JSON-Felder, URLs, Mail-Bodies, HTTP-Header.',
+  'tools.base64.explainer.mechanic':
+    'Nimm 3 Bytes (24 Bit), zerlege sie in 4 Gruppen zu je 6 Bit, schlage jede Gruppe im Alphabet nach und gib 4 ASCII-Zeichen aus. Das abschließende `=` füllt die Ausgabe auf ein Vielfaches von 4 auf, wenn die Eingabe nicht passt.',
+  'tools.base64.explainer.example.label': 'Beispielrechnung — "Cat" kodieren',
+  'tools.base64.explainer.uses':
+    'Du siehst es in HTTP Basic Auth (`Authorization: Basic …`), JWT-Segmenten, `data:`-URIs in CSS/HTML und E-Mail-Anhängen (MIME).',
+  'tools.base64.explainer.warning':
+    'Keine Verschlüsselung. Wer den kodierten String hat, kann ihn zurückdekodieren. Behandle base64 als Transportumschlag, nie als Geheimnis.',
+  'tools.base64.explainer.tryauth': 'Probier den Basic-Auth-Helfer →',
+  'tools.basicauth.mode.aria': 'Header bauen oder lesen',
+  'tools.basicauth.mode.encode': 'Bauen',
+  'tools.basicauth.mode.decode': 'Lesen',
+  'tools.basicauth.username.label': 'Benutzername',
+  'tools.basicauth.username.aria': 'Benutzername für Basic Auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Passwort',
+  'tools.basicauth.password.aria': 'Passwort für Basic Auth',
+  'tools.basicauth.password.placeholder': 'Sesam öffne dich',
+  'tools.basicauth.password.show': 'Zeigen',
+  'tools.basicauth.password.hide': 'Verbergen',
+  'tools.basicauth.header.label': 'Authorization-Header',
+  'tools.basicauth.header.aria': 'Wert des HTTP-Authorization-Headers',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Header kopieren',
+  'tools.basicauth.copy.username': 'Benutzername kopieren',
+  'tools.basicauth.copy.password': 'Passwort kopieren',
+  'tools.basicauth.paste.header': 'Header einfügen',
+  'tools.basicauth.invalid':
+    'Dieser Header ließ sich nicht lesen. Stelle sicher, dass er `Basic <base64>` lautet und die dekodierte Nutzlast einen `:` zwischen Benutzer und Passwort enthält.',
+  'tools.basicauth.intro':
+    'Baut und liest den Header `Authorization: Basic <base64>`, den HTTP Basic Authentication verwendet. Alles lokal — die Anmeldedaten verlassen den Browser nie.',
 };
 
 const pt: Translations = {
@@ -189,6 +321,8 @@ const pt: Translations = {
   'sidebar.foot.line2': 'Feito por Pratiyush.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'Repositório do GitHub',
+  'topbar.language.aria': 'Idioma',
+  'topbar.language.label': 'Idioma',
   'tool.placeholder.title': 'Ferramenta ainda não implementada',
   'tool.placeholder.body': 'Lógica da ferramenta disponível; camada de renderização pendente.',
   'footer.privacy': 'Privacidade',
@@ -203,6 +337,8 @@ const pt: Translations = {
     'Algo quebrou. A causa não está totalmente clara, nem para nós. Recarregar costuma ajudar.',
   'error.copy.failed':
     'A área de transferência disse não. Provavelmente é uma questão de permissões — verifica o navegador e tenta de novo.',
+  'error.paste.failed':
+    'A área de transferência ficou em silêncio. Os navegadores travam o colar atrás de uma permissão — concede, ou cola com ⌘/Ctrl-V no campo.',
   'error.parse.failed':
     'Isso não parece muito certo. Verifica caracteres soltos ou formato errado e tenta de novo.',
   'error.back.home': '← Voltar ao início',
@@ -211,15 +347,55 @@ const pt: Translations = {
   'tools.base64.mode.decode': 'Decodificar',
   'tools.base64.urlsafe.label': 'Variante URL-safe (-_, sem padding)',
   'tools.base64.urlsafe.aria': 'Usar alfabeto base64 URL-safe',
-  'tools.base64.input.label': 'Entrada',
-  'tools.base64.input.aria': 'Entrada do conversor base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Texto',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Entrada do conversor base64',
+  'tools.base64.result.aria': 'Saída do conversor base64',
+  'tools.base64.placeholder.encode':
     'Digite ou cole — UTF-8, emoji, segmentos JWT. Tudo faz round-trip limpo.',
-  'tools.base64.output.label': 'Saída',
-  'tools.base64.output.aria': 'Saída do conversor base64',
+  'tools.base64.placeholder.decode':
+    'Cola uma string base64 — segmentos JWT e variantes URL-safe também decodificam.',
   'tools.base64.swap': 'Trocar ⇄',
   'tools.base64.copy': 'Copiar',
+  'tools.base64.copied': 'Copiado',
+  'tools.base64.paste': 'Colar',
+  'tools.base64.paste.aria': 'Colar da área de transferência',
+  'tools.base64.pasted': 'Colado',
+  'tools.base64.chars': '{n} caracteres',
   'tools.base64.lengths': '{in} caracteres entrada · {out} caracteres saída',
+  'tools.base64.explainer.heading': 'Como funciona o Base64',
+  'tools.base64.explainer.intro':
+    'Base64 empacota bytes arbitrários em 64 caracteres ASCII imprimíveis (A–Z, a–z, 0–9, + /). Existe para que binário sobreviva a canais somente texto: campos JSON, URLs, corpos de e-mail, cabeçalhos HTTP.',
+  'tools.base64.explainer.mechanic':
+    'Pega 3 bytes (24 bits), corta em 4 grupos de 6 bits, procura cada grupo no alfabeto e emite 4 caracteres ASCII. O `=` final completa a saída até um múltiplo de 4 quando a entrada não bate.',
+  'tools.base64.explainer.example.label': 'Exemplo passo a passo — codificar "Cat"',
+  'tools.base64.explainer.uses':
+    'Aparece no HTTP Basic Auth (`Authorization: Basic …`), em segmentos de JWT, URIs `data:` em CSS/HTML e em anexos de e-mail (MIME).',
+  'tools.base64.explainer.warning':
+    'Não é criptografia. Qualquer pessoa com a string codificada consegue decodificar de volta. Trate base64 como envelope de transporte, nunca como segredo.',
+  'tools.base64.explainer.tryauth': 'Experimenta o ajudante de Basic Auth →',
+  'tools.basicauth.mode.aria': 'Construir ou ler o cabeçalho',
+  'tools.basicauth.mode.encode': 'Construir',
+  'tools.basicauth.mode.decode': 'Ler',
+  'tools.basicauth.username.label': 'Usuário',
+  'tools.basicauth.username.aria': 'Usuário para Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Senha',
+  'tools.basicauth.password.aria': 'Senha para Basic auth',
+  'tools.basicauth.password.placeholder': 'abra-te sésamo',
+  'tools.basicauth.password.show': 'Mostrar',
+  'tools.basicauth.password.hide': 'Esconder',
+  'tools.basicauth.header.label': 'Cabeçalho Authorization',
+  'tools.basicauth.header.aria': 'Valor do cabeçalho HTTP Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Copiar cabeçalho',
+  'tools.basicauth.copy.username': 'Copiar usuário',
+  'tools.basicauth.copy.password': 'Copiar senha',
+  'tools.basicauth.paste.header': 'Colar cabeçalho',
+  'tools.basicauth.invalid':
+    'Esse cabeçalho não pôde ser lido. Confere se tem o formato `Basic <base64>` e se o conteúdo decodificado contém `:` entre usuário e senha.',
+  'tools.basicauth.intro':
+    'Constrói e lê o cabeçalho `Authorization: Basic <base64>` usado pela autenticação HTTP Basic. Tudo local — as credenciais nunca saem do seu navegador.',
 };
 
 const it: Translations = {
@@ -241,6 +417,8 @@ const it: Translations = {
   'sidebar.foot.line2': 'Realizzato da Pratiyush.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'Repository GitHub',
+  'topbar.language.aria': 'Lingua',
+  'topbar.language.label': 'Lingua',
   'tool.placeholder.title': 'Strumento non ancora implementato',
   'tool.placeholder.body': 'Logica dello strumento disponibile; livello di rendering in sospeso.',
   'footer.privacy': 'Privacy',
@@ -255,6 +433,8 @@ const it: Translations = {
     'Qualcosa si è rotto. La causa non è del tutto chiara, nemmeno per noi. Ricaricare di solito aiuta.',
   'error.copy.failed':
     'Gli appunti hanno detto no. Probabilmente è una questione di permessi — controlla il browser e riprova.',
+  'error.paste.failed':
+    'Gli appunti sono rimasti zitti. I browser nascondono l’incollare dietro un permesso — concedilo, o incolla con ⌘/Ctrl-V nel campo.',
   'error.parse.failed':
     'Non sembra del tutto giusto. Controlla caratteri estranei o formato sbagliato e riprova.',
   'error.back.home': '← Torna alla home',
@@ -263,15 +443,55 @@ const it: Translations = {
   'tools.base64.mode.decode': 'Decodifica',
   'tools.base64.urlsafe.label': 'Variante URL-safe (-_, senza padding)',
   'tools.base64.urlsafe.aria': 'Usa alfabeto base64 URL-safe',
-  'tools.base64.input.label': 'Input',
-  'tools.base64.input.aria': 'Input del convertitore base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Testo',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Input del convertitore base64',
+  'tools.base64.result.aria': 'Output del convertitore base64',
+  'tools.base64.placeholder.encode':
     'Scrivi o incolla — UTF-8, emoji, segmenti JWT. Tutto torna integro.',
-  'tools.base64.output.label': 'Output',
-  'tools.base64.output.aria': 'Output del convertitore base64',
+  'tools.base64.placeholder.decode':
+    'Incolla una stringa base64 — segmenti JWT e varianti URL-safe si decodificano allo stesso modo.',
   'tools.base64.swap': 'Scambia ⇄',
   'tools.base64.copy': 'Copia',
+  'tools.base64.copied': 'Copiato',
+  'tools.base64.paste': 'Incolla',
+  'tools.base64.paste.aria': 'Incolla dagli appunti',
+  'tools.base64.pasted': 'Incollato',
+  'tools.base64.chars': '{n} caratteri',
   'tools.base64.lengths': '{in} caratteri input · {out} caratteri output',
+  'tools.base64.explainer.heading': 'Come funziona Base64',
+  'tools.base64.explainer.intro':
+    'Base64 impacchetta byte arbitrari in 64 caratteri ASCII stampabili (A–Z, a–z, 0–9, + /). Esiste perché il binario sopravviva ai canali solo testo: campi JSON, URL, corpi email, header HTTP.',
+  'tools.base64.explainer.mechanic':
+    'Prendi 3 byte (24 bit), affettali in 4 gruppi da 6 bit, cerca ogni gruppo nell’alfabeto ed emetti 4 caratteri ASCII. Il `=` finale porta la lunghezza a un multiplo di 4 quando l’input non torna.',
+  'tools.base64.explainer.example.label': 'Esempio guidato — codificare "Cat"',
+  'tools.base64.explainer.uses':
+    'Lo vedi in HTTP Basic Auth (`Authorization: Basic …`), nei segmenti JWT, nelle URI `data:` in CSS/HTML e negli allegati email (MIME).',
+  'tools.base64.explainer.warning':
+    'Non è cifratura. Chiunque abbia la stringa codificata può decodificarla. Tratta base64 come una busta di trasporto, mai come un segreto.',
+  'tools.base64.explainer.tryauth': 'Prova l’aiutante Basic Auth →',
+  'tools.basicauth.mode.aria': 'Costruisci o leggi l’header',
+  'tools.basicauth.mode.encode': 'Costruisci',
+  'tools.basicauth.mode.decode': 'Leggi',
+  'tools.basicauth.username.label': 'Utente',
+  'tools.basicauth.username.aria': 'Utente per Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Password',
+  'tools.basicauth.password.aria': 'Password per Basic auth',
+  'tools.basicauth.password.placeholder': 'apriti sesamo',
+  'tools.basicauth.password.show': 'Mostra',
+  'tools.basicauth.password.hide': 'Nascondi',
+  'tools.basicauth.header.label': 'Header Authorization',
+  'tools.basicauth.header.aria': 'Valore dell’header HTTP Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Copia header',
+  'tools.basicauth.copy.username': 'Copia utente',
+  'tools.basicauth.copy.password': 'Copia password',
+  'tools.basicauth.paste.header': 'Incolla header',
+  'tools.basicauth.invalid':
+    'Questo header non è stato letto. Assicurati che abbia la forma `Basic <base64>` e che il payload decodificato contenga `:` tra utente e password.',
+  'tools.basicauth.intro':
+    'Costruisce e legge l’header `Authorization: Basic <base64>` usato dall’autenticazione HTTP Basic. Tutto in locale — le credenziali non lasciano mai il tuo browser.',
 };
 
 const nl: Translations = {
@@ -293,6 +513,8 @@ const nl: Translations = {
   'sidebar.foot.line2': 'Gemaakt door Pratiyush.',
   'topbar.theme.aria': 'Thema',
   'topbar.github.aria': 'GitHub-repository',
+  'topbar.language.aria': 'Taal',
+  'topbar.language.label': 'Taal',
   'tool.placeholder.title': 'Tool nog niet geïmplementeerd',
   'tool.placeholder.body': 'Tool-logica beschikbaar; rendering-laag in afwachting.',
   'footer.privacy': 'Privacy',
@@ -307,6 +529,8 @@ const nl: Translations = {
     'Er is iets stuk. De oorzaak is ons niet helemaal duidelijk. Opnieuw laden helpt meestal.',
   'error.copy.failed':
     'Het klembord zei nee. Waarschijnlijk rechten — kijk in je browser en probeer het nog eens.',
+  'error.paste.failed':
+    'Het klembord hield zich stil. Browsers schermen plakken af achter een rechtenpoortje — geef toestemming, of plak met ⌘/Ctrl-V in het veld.',
   'error.parse.failed':
     'Dat klopt niet helemaal. Controleer op vreemde tekens of verkeerd formaat en probeer opnieuw.',
   'error.back.home': '← Terug naar home',
@@ -315,15 +539,55 @@ const nl: Translations = {
   'tools.base64.mode.decode': 'Decoderen',
   'tools.base64.urlsafe.label': 'URL-veilige variant (-_, geen padding)',
   'tools.base64.urlsafe.aria': 'URL-veilig base64-alfabet gebruiken',
-  'tools.base64.input.label': 'Invoer',
-  'tools.base64.input.aria': 'Base64-converter-invoer',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Tekst',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64-converter-invoer',
+  'tools.base64.result.aria': 'Base64-converter-uitvoer',
+  'tools.base64.placeholder.encode':
     'Typ of plak — UTF-8, emoji, JWT-segmenten. Alles maakt schoon de round-trip.',
-  'tools.base64.output.label': 'Uitvoer',
-  'tools.base64.output.aria': 'Base64-converter-uitvoer',
+  'tools.base64.placeholder.decode':
+    'Plak een base64-string — JWT-segmenten en URL-veilige varianten decoderen ook.',
   'tools.base64.swap': 'Wisselen ⇄',
   'tools.base64.copy': 'Kopiëren',
+  'tools.base64.copied': 'Gekopieerd',
+  'tools.base64.paste': 'Plakken',
+  'tools.base64.paste.aria': 'Plakken vanuit klembord',
+  'tools.base64.pasted': 'Geplakt',
+  'tools.base64.chars': '{n} tekens',
   'tools.base64.lengths': '{in} tekens invoer · {out} tekens uitvoer',
+  'tools.base64.explainer.heading': 'Hoe Base64 werkt',
+  'tools.base64.explainer.intro':
+    'Base64 verpakt willekeurige bytes in 64 afdrukbare ASCII-tekens (A–Z, a–z, 0–9, + /). Het bestaat opdat binair tekenkanalen overleeft: JSON-velden, URL’s, mail-bodies, HTTP-headers.',
+  'tools.base64.explainer.mechanic':
+    'Neem 3 bytes (24 bits), snijd in 4 groepen van 6 bits, zoek elke groep op in het alfabet, en geef 4 ASCII-tekens uit. Een afsluitende `=` vult de uitvoer aan tot een veelvoud van 4 als de invoer niet uitkomt.',
+  'tools.base64.explainer.example.label': 'Uitgewerkt voorbeeld — "Cat" coderen',
+  'tools.base64.explainer.uses':
+    'Je ziet het in HTTP Basic Auth (`Authorization: Basic …`), JWT-segmenten, `data:`-URI’s in CSS/HTML en mail-bijlagen (MIME).',
+  'tools.base64.explainer.warning':
+    'Geen versleuteling. Iedereen met de gecodeerde string kan hem terug decoderen. Behandel base64 als transportenvelop, nooit als geheim.',
+  'tools.base64.explainer.tryauth': 'Probeer de Basic-Auth-helper →',
+  'tools.basicauth.mode.aria': 'Header bouwen of lezen',
+  'tools.basicauth.mode.encode': 'Bouwen',
+  'tools.basicauth.mode.decode': 'Lezen',
+  'tools.basicauth.username.label': 'Gebruikersnaam',
+  'tools.basicauth.username.aria': 'Gebruikersnaam voor Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Wachtwoord',
+  'tools.basicauth.password.aria': 'Wachtwoord voor Basic auth',
+  'tools.basicauth.password.placeholder': 'sesam open u',
+  'tools.basicauth.password.show': 'Tonen',
+  'tools.basicauth.password.hide': 'Verbergen',
+  'tools.basicauth.header.label': 'Authorization-header',
+  'tools.basicauth.header.aria': 'Waarde van de HTTP Authorization-header',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Header kopiëren',
+  'tools.basicauth.copy.username': 'Gebruikersnaam kopiëren',
+  'tools.basicauth.copy.password': 'Wachtwoord kopiëren',
+  'tools.basicauth.paste.header': 'Header plakken',
+  'tools.basicauth.invalid':
+    'Die header kon niet gelezen worden. Zorg dat hij eruitziet als `Basic <base64>` en dat de gedecodeerde inhoud een `:` bevat tussen gebruikersnaam en wachtwoord.',
+  'tools.basicauth.intro':
+    'Bouwt en leest de `Authorization: Basic <base64>`-header die HTTP Basic Authentication gebruikt. Alles lokaal — gegevens verlaten je browser nooit.',
 };
 
 const pl: Translations = {
@@ -345,6 +609,8 @@ const pl: Translations = {
   'sidebar.foot.line2': 'Stworzone przez Pratiyusha.',
   'topbar.theme.aria': 'Motyw',
   'topbar.github.aria': 'Repozytorium GitHub',
+  'topbar.language.aria': 'Język',
+  'topbar.language.label': 'Język',
   'tool.placeholder.title': 'Narzędzie jeszcze nie zaimplementowane',
   'tool.placeholder.body': 'Logika narzędzia dostępna; warstwa renderowania oczekuje.',
   'footer.privacy': 'Prywatność',
@@ -359,6 +625,8 @@ const pl: Translations = {
     'Coś się zepsuło. Przyczyna nie jest do końca jasna, nawet dla nas. Przeładowanie zwykle pomaga.',
   'error.copy.failed':
     'Schowek powiedział nie. Pewnie uprawnienia — sprawdź przeglądarkę i spróbuj jeszcze raz.',
+  'error.paste.failed':
+    'Schowek milczy. Przeglądarki blokują wklejanie za uprawnieniem — udziel go albo wklej skrótem ⌘/Ctrl-V w polu.',
   'error.parse.failed':
     'To nie wygląda zbyt prawidłowo. Sprawdź zbędne znaki lub zły format i spróbuj ponownie.',
   'error.back.home': '← Wróć do strony głównej',
@@ -367,15 +635,55 @@ const pl: Translations = {
   'tools.base64.mode.decode': 'Dekoduj',
   'tools.base64.urlsafe.label': 'Wariant URL-safe (-_, bez paddingu)',
   'tools.base64.urlsafe.aria': 'Użyj alfabetu base64 URL-safe',
-  'tools.base64.input.label': 'Wejście',
-  'tools.base64.input.aria': 'Wejście konwertera base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Tekst',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Wejście konwertera base64',
+  'tools.base64.result.aria': 'Wyjście konwertera base64',
+  'tools.base64.placeholder.encode':
     'Wpisz lub wklej — UTF-8, emoji, segmenty JWT. Wszystko czysto wraca w obie strony.',
-  'tools.base64.output.label': 'Wyjście',
-  'tools.base64.output.aria': 'Wyjście konwertera base64',
+  'tools.base64.placeholder.decode':
+    'Wklej ciąg base64 — segmenty JWT i warianty URL-safe również się dekodują.',
   'tools.base64.swap': 'Zamień ⇄',
   'tools.base64.copy': 'Kopiuj',
+  'tools.base64.copied': 'Skopiowano',
+  'tools.base64.paste': 'Wklej',
+  'tools.base64.paste.aria': 'Wklej ze schowka',
+  'tools.base64.pasted': 'Wklejono',
+  'tools.base64.chars': '{n} znaków',
   'tools.base64.lengths': '{in} znaków wejście · {out} znaków wyjście',
+  'tools.base64.explainer.heading': 'Jak działa Base64',
+  'tools.base64.explainer.intro':
+    'Base64 pakuje dowolne bajty w 64 drukowalne znaki ASCII (A–Z, a–z, 0–9, + /). Istnieje po to, by binarne dane przeżyły kanały tylko-tekstowe: pola JSON, URL-e, treści e-maili, nagłówki HTTP.',
+  'tools.base64.explainer.mechanic':
+    'Weź 3 bajty (24 bity), pokrój je na 4 grupy po 6 bitów, sprawdź każdą grupę w alfabecie i wyrzuć 4 znaki ASCII. Końcowe `=` uzupełnia wyjście do wielokrotności 4, gdy wejście się nie składa.',
+  'tools.base64.explainer.example.label': 'Przykład krok po kroku — kodowanie "Cat"',
+  'tools.base64.explainer.uses':
+    'Spotkasz go w HTTP Basic Auth (`Authorization: Basic …`), w segmentach JWT, w URI `data:` w CSS/HTML oraz w załącznikach e-mail (MIME).',
+  'tools.base64.explainer.warning':
+    'To nie szyfrowanie. Każdy z zakodowanym ciągiem może go zdekodować. Traktuj base64 jako kopertę transportową, nigdy jako sekret.',
+  'tools.base64.explainer.tryauth': 'Wypróbuj pomocnika Basic Auth →',
+  'tools.basicauth.mode.aria': 'Zbuduj lub odczytaj nagłówek',
+  'tools.basicauth.mode.encode': 'Zbuduj',
+  'tools.basicauth.mode.decode': 'Odczytaj',
+  'tools.basicauth.username.label': 'Użytkownik',
+  'tools.basicauth.username.aria': 'Użytkownik dla Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Hasło',
+  'tools.basicauth.password.aria': 'Hasło dla Basic auth',
+  'tools.basicauth.password.placeholder': 'sezamie otwórz się',
+  'tools.basicauth.password.show': 'Pokaż',
+  'tools.basicauth.password.hide': 'Ukryj',
+  'tools.basicauth.header.label': 'Nagłówek Authorization',
+  'tools.basicauth.header.aria': 'Wartość nagłówka HTTP Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Kopiuj nagłówek',
+  'tools.basicauth.copy.username': 'Kopiuj użytkownika',
+  'tools.basicauth.copy.password': 'Kopiuj hasło',
+  'tools.basicauth.paste.header': 'Wklej nagłówek',
+  'tools.basicauth.invalid':
+    'Tego nagłówka nie udało się odczytać. Upewnij się, że ma postać `Basic <base64>`, a zdekodowany ładunek zawiera `:` między użytkownikiem a hasłem.',
+  'tools.basicauth.intro':
+    'Buduje i odczytuje nagłówek `Authorization: Basic <base64>` używany przez uwierzytelnianie HTTP Basic. Wszystko lokalnie — dane nigdy nie opuszczają Twojej przeglądarki.',
 };
 
 const ru: Translations = {
@@ -397,6 +705,8 @@ const ru: Translations = {
   'sidebar.foot.line2': 'Сделано Pratiyush.',
   'topbar.theme.aria': 'Тема',
   'topbar.github.aria': 'Репозиторий GitHub',
+  'topbar.language.aria': 'Язык',
+  'topbar.language.label': 'Язык',
   'tool.placeholder.title': 'Инструмент ещё не реализован',
   'tool.placeholder.body': 'Логика инструмента доступна; слой отрисовки ожидает.',
   'footer.privacy': 'Конфиденциальность',
@@ -411,6 +721,8 @@ const ru: Translations = {
     'Что-то сломалось. Причина не до конца ясна даже нам. Обычно помогает перезагрузка.',
   'error.copy.failed':
     'Буфер обмена отказал. Скорее всего, разрешения — проверьте настройки браузера и попробуйте ещё раз.',
+  'error.paste.failed':
+    'Буфер обмена промолчал. Браузеры закрывают вставку за разрешением — выдайте его или вставьте вручную с ⌘/Ctrl-V.',
   'error.parse.failed':
     'Это выглядит не совсем правильно. Проверьте лишние символы или неверный формат и попробуйте снова.',
   'error.back.home': '← Вернуться на главную',
@@ -419,15 +731,55 @@ const ru: Translations = {
   'tools.base64.mode.decode': 'Декодировать',
   'tools.base64.urlsafe.label': 'URL-безопасный вариант (-_, без padding)',
   'tools.base64.urlsafe.aria': 'Использовать URL-безопасный алфавит base64',
-  'tools.base64.input.label': 'Ввод',
-  'tools.base64.input.aria': 'Ввод конвертера base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Текст',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Ввод конвертера base64',
+  'tools.base64.result.aria': 'Вывод конвертера base64',
+  'tools.base64.placeholder.encode':
     'Введите или вставьте — UTF-8, эмодзи, сегменты JWT. Всё чисто проходит туда и обратно.',
-  'tools.base64.output.label': 'Вывод',
-  'tools.base64.output.aria': 'Вывод конвертера base64',
+  'tools.base64.placeholder.decode':
+    'Вставьте строку base64 — сегменты JWT и URL-безопасные варианты тоже декодируются.',
   'tools.base64.swap': 'Поменять ⇄',
   'tools.base64.copy': 'Копировать',
+  'tools.base64.copied': 'Скопировано',
+  'tools.base64.paste': 'Вставить',
+  'tools.base64.paste.aria': 'Вставить из буфера обмена',
+  'tools.base64.pasted': 'Вставлено',
+  'tools.base64.chars': '{n} символов',
   'tools.base64.lengths': '{in} символов ввод · {out} символов вывод',
+  'tools.base64.explainer.heading': 'Как работает Base64',
+  'tools.base64.explainer.intro':
+    'Base64 упаковывает произвольные байты в 64 печатаемых ASCII-символа (A–Z, a–z, 0–9, + /). Он существует, чтобы двоичные данные пережили каналы только для текста: поля JSON, URL, тела писем, HTTP-заголовки.',
+  'tools.base64.explainer.mechanic':
+    'Возьмите 3 байта (24 бита), разрежьте на 4 группы по 6 бит, найдите каждую группу в алфавите и выдайте 4 ASCII-символа. Завершающий `=` дополняет вывод до кратного 4, когда вход не выровнен.',
+  'tools.base64.explainer.example.label': 'Разбор примера — кодируем "Cat"',
+  'tools.base64.explainer.uses':
+    'Вы встретите его в HTTP Basic Auth (`Authorization: Basic …`), сегментах JWT, URI `data:` в CSS/HTML и в почтовых вложениях (MIME).',
+  'tools.base64.explainer.warning':
+    'Это не шифрование. Любой с закодированной строкой раскодирует её обратно. Считайте base64 транспортным конвертом, не секретом.',
+  'tools.base64.explainer.tryauth': 'Попробуйте помощник Basic Auth →',
+  'tools.basicauth.mode.aria': 'Собрать или прочитать заголовок',
+  'tools.basicauth.mode.encode': 'Собрать',
+  'tools.basicauth.mode.decode': 'Прочитать',
+  'tools.basicauth.username.label': 'Логин',
+  'tools.basicauth.username.aria': 'Логин для Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Пароль',
+  'tools.basicauth.password.aria': 'Пароль для Basic auth',
+  'tools.basicauth.password.placeholder': 'сезам откройся',
+  'tools.basicauth.password.show': 'Показать',
+  'tools.basicauth.password.hide': 'Скрыть',
+  'tools.basicauth.header.label': 'Заголовок Authorization',
+  'tools.basicauth.header.aria': 'Значение HTTP-заголовка Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Скопировать заголовок',
+  'tools.basicauth.copy.username': 'Скопировать логин',
+  'tools.basicauth.copy.password': 'Скопировать пароль',
+  'tools.basicauth.paste.header': 'Вставить заголовок',
+  'tools.basicauth.invalid':
+    'Этот заголовок не разобрался. Убедитесь, что он имеет вид `Basic <base64>` и в декодированной нагрузке есть `:` между логином и паролем.',
+  'tools.basicauth.intro':
+    'Собирает и разбирает заголовок `Authorization: Basic <base64>`, используемый HTTP Basic Authentication. Всё локально — учётные данные не покидают браузер.',
 };
 
 const tr: Translations = {
@@ -449,6 +801,8 @@ const tr: Translations = {
   'sidebar.foot.line2': 'Pratiyush tarafından yapıldı.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'GitHub deposu',
+  'topbar.language.aria': 'Dil',
+  'topbar.language.label': 'Dil',
   'tool.placeholder.title': 'Araç henüz uygulanmadı',
   'tool.placeholder.body': 'Araç mantığı mevcut; oluşturma katmanı bekliyor.',
   'footer.privacy': 'Gizlilik',
@@ -463,6 +817,8 @@ const tr: Translations = {
     'Bir şey kırıldı. Sebep tam olarak bize de net değil. Sayfayı yeniden yüklemek genelde işe yarar.',
   'error.copy.failed':
     'Pano hayır dedi. Muhtemelen izin meselesi — tarayıcı ayarlarını kontrol edip yeniden dene.',
+  'error.paste.failed':
+    'Pano sustu. Tarayıcılar yapıştırmayı izin arkasında tutar — izin ver, ya da alana ⌘/Ctrl-V ile doğrudan yapıştır.',
   'error.parse.failed':
     'Bu pek doğru görünmüyor. Garip karakter veya yanlış biçim var mı bak, yeniden dene.',
   'error.back.home': '← Ana sayfaya dön',
@@ -471,15 +827,55 @@ const tr: Translations = {
   'tools.base64.mode.decode': 'Çöz',
   'tools.base64.urlsafe.label': 'URL-güvenli varyant (-_, padding yok)',
   'tools.base64.urlsafe.aria': 'URL-güvenli base64 alfabesini kullan',
-  'tools.base64.input.label': 'Girdi',
-  'tools.base64.input.aria': 'Base64 dönüştürücü girdi',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Metin',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64 dönüştürücü girdi',
+  'tools.base64.result.aria': 'Base64 dönüştürücü çıktı',
+  'tools.base64.placeholder.encode':
     'Yaz veya yapıştır — UTF-8, emoji, JWT segmentleri. Hepsi temiz şekilde gidip geliyor.',
-  'tools.base64.output.label': 'Çıktı',
-  'tools.base64.output.aria': 'Base64 dönüştürücü çıktı',
+  'tools.base64.placeholder.decode':
+    'Bir base64 dizesi yapıştır — JWT segmentleri ve URL-güvenli varyantlar da çözülür.',
   'tools.base64.swap': 'Değiştir ⇄',
   'tools.base64.copy': 'Kopyala',
+  'tools.base64.copied': 'Kopyalandı',
+  'tools.base64.paste': 'Yapıştır',
+  'tools.base64.paste.aria': 'Panodan yapıştır',
+  'tools.base64.pasted': 'Yapıştırıldı',
+  'tools.base64.chars': '{n} karakter',
   'tools.base64.lengths': '{in} karakter girdi · {out} karakter çıktı',
+  'tools.base64.explainer.heading': 'Base64 nasıl çalışır',
+  'tools.base64.explainer.intro':
+    'Base64 keyfi baytları 64 yazdırılabilir ASCII karaktere paketler (A–Z, a–z, 0–9, + /). İkilinin yalnızca metin kanallarında — JSON alanları, URL’ler, e-posta gövdeleri, HTTP başlıkları — sağ kalması için var.',
+  'tools.base64.explainer.mechanic':
+    '3 bayt (24 bit) al, 4 gruba (her biri 6 bit) böl, her grubu alfabede bul, 4 ASCII karakter yay. Sondaki `=`, girdi tutmadığında çıktıyı 4’ün katına tamamlar.',
+  'tools.base64.explainer.example.label': 'Adım adım örnek — "Cat" kodlama',
+  'tools.base64.explainer.uses':
+    'HTTP Basic Auth (`Authorization: Basic …`), JWT segmentleri, CSS/HTML’deki `data:` URI’leri ve e-posta eklerinde (MIME) görürsün.',
+  'tools.base64.explainer.warning':
+    'Şifreleme değildir. Kodlanmış diziye sahip olan herkes geri çözebilir. Base64’ü taşıma zarfı say, asla sır olarak kullanma.',
+  'tools.base64.explainer.tryauth': 'Basic Auth yardımcısını dene →',
+  'tools.basicauth.mode.aria': 'Başlık oluştur veya oku',
+  'tools.basicauth.mode.encode': 'Oluştur',
+  'tools.basicauth.mode.decode': 'Oku',
+  'tools.basicauth.username.label': 'Kullanıcı adı',
+  'tools.basicauth.username.aria': 'Basic auth için kullanıcı adı',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Şifre',
+  'tools.basicauth.password.aria': 'Basic auth için şifre',
+  'tools.basicauth.password.placeholder': 'açıl susam açıl',
+  'tools.basicauth.password.show': 'Göster',
+  'tools.basicauth.password.hide': 'Gizle',
+  'tools.basicauth.header.label': 'Authorization başlığı',
+  'tools.basicauth.header.aria': 'HTTP Authorization başlığının değeri',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Başlığı kopyala',
+  'tools.basicauth.copy.username': 'Kullanıcı adını kopyala',
+  'tools.basicauth.copy.password': 'Şifreyi kopyala',
+  'tools.basicauth.paste.header': 'Başlığı yapıştır',
+  'tools.basicauth.invalid':
+    'O başlık çözülemedi. `Basic <base64>` formatında olduğundan ve çözülmüş içerikte kullanıcı ile şifre arasında `:` bulunduğundan emin ol.',
+  'tools.basicauth.intro':
+    'HTTP Basic Authentication’ın kullandığı `Authorization: Basic <base64>` başlığını oluşturur ve okur. Hepsi cihazda — kimlik bilgileri tarayıcından çıkmaz.',
 };
 
 const ja: Translations = {
@@ -501,6 +897,8 @@ const ja: Translations = {
   'sidebar.foot.line2': 'Pratiyush が制作。',
   'topbar.theme.aria': 'テーマ',
   'topbar.github.aria': 'GitHub リポジトリ',
+  'topbar.language.aria': '言語',
+  'topbar.language.label': '言語',
   'tool.placeholder.title': 'ツールはまだ実装されていません',
   'tool.placeholder.body': 'ツールロジックは利用可能；レンダリング層は保留中。',
   'footer.privacy': 'プライバシー',
@@ -515,6 +913,8 @@ const ja: Translations = {
     '何かが壊れました。原因は私たちにもよく分かりません。再読み込みでだいたい直ります。',
   'error.copy.failed':
     'クリップボードに拒否されました。たぶん権限の問題です — ブラウザの設定を確認して、もう一度試してください。',
+  'error.paste.failed':
+    'クリップボードは黙秘しました。ブラウザは貼り付けを許可制にしています — 許可するか、入力欄に ⌘/Ctrl-V で直接貼ってください。',
   'error.parse.failed':
     '何かが違うようです。余分な文字や形式の誤りがないか確認して、もう一度試してください。',
   'error.back.home': '← ホームに戻る',
@@ -523,15 +923,55 @@ const ja: Translations = {
   'tools.base64.mode.decode': 'デコード',
   'tools.base64.urlsafe.label': 'URL安全バリアント (-_, パディングなし)',
   'tools.base64.urlsafe.aria': 'URL安全な base64 アルファベットを使用',
-  'tools.base64.input.label': '入力',
-  'tools.base64.input.aria': 'Base64 コンバータ入力',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'テキスト',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64 コンバータ入力',
+  'tools.base64.result.aria': 'Base64 コンバータ出力',
+  'tools.base64.placeholder.encode':
     '入力または貼り付け — UTF-8、絵文字、JWT セグメント。すべてクリーンに往復します。',
-  'tools.base64.output.label': '出力',
-  'tools.base64.output.aria': 'Base64 コンバータ出力',
+  'tools.base64.placeholder.decode':
+    'base64 文字列を貼り付け — JWT セグメントや URL 安全バリアントもデコードされます。',
   'tools.base64.swap': '入れ替え ⇄',
   'tools.base64.copy': 'コピー',
+  'tools.base64.copied': 'コピー済み',
+  'tools.base64.paste': '貼り付け',
+  'tools.base64.paste.aria': 'クリップボードから貼り付け',
+  'tools.base64.pasted': '貼り付け済み',
+  'tools.base64.chars': '{n} 文字',
   'tools.base64.lengths': '入力 {in} 文字 · 出力 {out} 文字',
+  'tools.base64.explainer.heading': 'Base64 の仕組み',
+  'tools.base64.explainer.intro':
+    'Base64 は任意のバイト列を 64 個の印字可能な ASCII 文字（A–Z、a–z、0–9、+ /）に詰め込みます。バイナリがテキスト専用の経路 — JSON フィールド、URL、メール本文、HTTP ヘッダ — を生き延びるために存在します。',
+  'tools.base64.explainer.mechanic':
+    '3 バイト（24 ビット）を取り、6 ビットずつ 4 グループに切り分け、各グループをアルファベットで引き、4 文字の ASCII を出力します。末尾の `=` は入力が揃わないときに長さを 4 の倍数に揃えるパディングです。',
+  'tools.base64.explainer.example.label': '実例 — "Cat" をエンコード',
+  'tools.base64.explainer.uses':
+    'HTTP Basic Auth（`Authorization: Basic …`）、JWT のセグメント、CSS/HTML の `data:` URI、メール添付（MIME）で目にします。',
+  'tools.base64.explainer.warning':
+    '暗号ではありません。エンコード文字列を持つ人なら誰でもデコードできます。Base64 は輸送用の封筒として扱い、決して秘密として使わないこと。',
+  'tools.base64.explainer.tryauth': 'Basic Auth ヘルパーを試す →',
+  'tools.basicauth.mode.aria': 'ヘッダを作成または読む',
+  'tools.basicauth.mode.encode': '作成',
+  'tools.basicauth.mode.decode': '読み取り',
+  'tools.basicauth.username.label': 'ユーザー名',
+  'tools.basicauth.username.aria': 'Basic auth のユーザー名',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'パスワード',
+  'tools.basicauth.password.aria': 'Basic auth のパスワード',
+  'tools.basicauth.password.placeholder': '開けゴマ',
+  'tools.basicauth.password.show': '表示',
+  'tools.basicauth.password.hide': '非表示',
+  'tools.basicauth.header.label': 'Authorization ヘッダ',
+  'tools.basicauth.header.aria': 'HTTP Authorization ヘッダの値',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'ヘッダをコピー',
+  'tools.basicauth.copy.username': 'ユーザー名をコピー',
+  'tools.basicauth.copy.password': 'パスワードをコピー',
+  'tools.basicauth.paste.header': 'ヘッダを貼り付け',
+  'tools.basicauth.invalid':
+    'そのヘッダは解析できませんでした。形式が `Basic <base64>` で、デコード後のペイロードのユーザー名とパスワードの間に `:` があることを確認してください。',
+  'tools.basicauth.intro':
+    'HTTP Basic 認証で使う `Authorization: Basic <base64>` ヘッダを作成・読み取りします。すべて端末内で完結 — 資格情報はブラウザを離れません。',
 };
 
 const zh: Translations = {
@@ -553,6 +993,8 @@ const zh: Translations = {
   'sidebar.foot.line2': '由 Pratiyush 制作。',
   'topbar.theme.aria': '主题',
   'topbar.github.aria': 'GitHub 仓库',
+  'topbar.language.aria': '语言',
+  'topbar.language.label': '语言',
   'tool.placeholder.title': '工具尚未实现',
   'tool.placeholder.body': '工具逻辑可用；渲染层待实现。',
   'footer.privacy': '隐私',
@@ -565,6 +1007,8 @@ const zh: Translations = {
     '没有叫 "{id}" 的工具。可能改名了、退役了，或者链接走错了路。主页知道回家的路。',
   'error.unknown': '出了点问题。原因连我们也不太清楚。重新加载通常有用。',
   'error.copy.failed': '剪贴板拒绝了。八成是权限问题 — 检查一下浏览器设置，再试一次。',
+  'error.paste.failed':
+    '剪贴板没吭声。浏览器把粘贴藏在权限之后 — 先授权，或者直接用 ⌘/Ctrl-V 粘到输入框里。',
   'error.parse.failed': '看起来不太对。检查一下多余的字符或错误格式，再试一次。',
   'error.back.home': '← 返回主页',
   'tools.base64.mode.aria': '编码或解码',
@@ -572,14 +1016,53 @@ const zh: Translations = {
   'tools.base64.mode.decode': '解码',
   'tools.base64.urlsafe.label': 'URL 安全变体 (-_, 无填充)',
   'tools.base64.urlsafe.aria': '使用 URL 安全的 base64 字母表',
-  'tools.base64.input.label': '输入',
-  'tools.base64.input.aria': 'Base64 转换器输入',
-  'tools.base64.input.placeholder': '输入或粘贴 — UTF-8、表情符号、JWT 段。全都干净地往返。',
-  'tools.base64.output.label': '输出',
-  'tools.base64.output.aria': 'Base64 转换器输出',
+  'tools.base64.label.text': '文本',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64 转换器输入',
+  'tools.base64.result.aria': 'Base64 转换器输出',
+  'tools.base64.placeholder.encode': '输入或粘贴 — UTF-8、表情符号、JWT 段。全都干净地往返。',
+  'tools.base64.placeholder.decode': '粘贴一段 base64 字符串 — JWT 片段和 URL-safe 变体都能解码。',
   'tools.base64.swap': '交换 ⇄',
   'tools.base64.copy': '复制',
+  'tools.base64.copied': '已复制',
+  'tools.base64.paste': '粘贴',
+  'tools.base64.paste.aria': '从剪贴板粘贴',
+  'tools.base64.pasted': '已粘贴',
+  'tools.base64.chars': '{n} 字符',
   'tools.base64.lengths': '输入 {in} 字符 · 输出 {out} 字符',
+  'tools.base64.explainer.heading': 'Base64 的原理',
+  'tools.base64.explainer.intro':
+    'Base64 把任意字节装进 64 个可打印 ASCII 字符（A–Z、a–z、0–9、+ /）。它的存在是为了让二进制能穿过只允许文本的通道：JSON 字段、URL、邮件正文、HTTP 头。',
+  'tools.base64.explainer.mechanic':
+    '拿 3 个字节（24 位），切成 4 组各 6 位，逐组在字母表里查表，输出 4 个 ASCII 字符。结尾的 `=` 是为了在输入不对齐时把输出补齐到 4 的倍数。',
+  'tools.base64.explainer.example.label': '走一遍：编码 "Cat"',
+  'tools.base64.explainer.uses':
+    '你会在 HTTP Basic Auth（`Authorization: Basic …`）、JWT 段、CSS/HTML 的 `data:` URI 和邮件附件（MIME）里看到它。',
+  'tools.base64.explainer.warning':
+    '它不是加密。任何拿到编码字符串的人都能把它解回来。把 base64 当成运输信封，永远别当作秘密。',
+  'tools.base64.explainer.tryauth': '试试 Basic Auth 助手 →',
+  'tools.basicauth.mode.aria': '生成或读取头',
+  'tools.basicauth.mode.encode': '生成',
+  'tools.basicauth.mode.decode': '读取',
+  'tools.basicauth.username.label': '用户名',
+  'tools.basicauth.username.aria': 'Basic auth 的用户名',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': '密码',
+  'tools.basicauth.password.aria': 'Basic auth 的密码',
+  'tools.basicauth.password.placeholder': '芝麻开门',
+  'tools.basicauth.password.show': '显示',
+  'tools.basicauth.password.hide': '隐藏',
+  'tools.basicauth.header.label': 'Authorization 头',
+  'tools.basicauth.header.aria': 'HTTP Authorization 头的值',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': '复制头',
+  'tools.basicauth.copy.username': '复制用户名',
+  'tools.basicauth.copy.password': '复制密码',
+  'tools.basicauth.paste.header': '粘贴头',
+  'tools.basicauth.invalid':
+    '没解析出这个头。请确认它形如 `Basic <base64>`，并且解码后的内容里用户名和密码之间有 `:`。',
+  'tools.basicauth.intro':
+    '生成并读取 HTTP Basic 认证使用的 `Authorization: Basic <base64>` 头。全程本地 — 凭据不会离开你的浏览器。',
 };
 
 const ko: Translations = {
@@ -601,6 +1084,8 @@ const ko: Translations = {
   'sidebar.foot.line2': 'Pratiyush 제작.',
   'topbar.theme.aria': '테마',
   'topbar.github.aria': 'GitHub 리포지토리',
+  'topbar.language.aria': '언어',
+  'topbar.language.label': '언어',
   'tool.placeholder.title': '도구가 아직 구현되지 않았습니다',
   'tool.placeholder.body': '도구 로직 사용 가능; 렌더링 계층 대기 중.',
   'footer.privacy': '개인정보 보호',
@@ -614,6 +1099,8 @@ const ko: Translations = {
   'error.unknown': '무언가 깨졌습니다. 원인은 우리도 잘 모릅니다. 새로 고침하면 보통 해결됩니다.',
   'error.copy.failed':
     '클립보드가 거부했습니다. 권한 문제일 가능성이 높습니다 — 브라우저 설정을 확인하고 다시 시도하세요.',
+  'error.paste.failed':
+    '클립보드가 입을 다물었습니다. 브라우저는 붙여넣기를 권한으로 막습니다 — 허용하거나, 입력란에 ⌘/Ctrl-V로 직접 붙여넣으세요.',
   'error.parse.failed':
     '뭔가 어긋난 것 같습니다. 이상한 문자나 잘못된 형식을 확인하고 다시 시도하세요.',
   'error.back.home': '← 홈으로 돌아가기',
@@ -622,15 +1109,55 @@ const ko: Translations = {
   'tools.base64.mode.decode': '디코딩',
   'tools.base64.urlsafe.label': 'URL 안전 변형 (-_, 패딩 없음)',
   'tools.base64.urlsafe.aria': 'URL 안전 base64 알파벳 사용',
-  'tools.base64.input.label': '입력',
-  'tools.base64.input.aria': 'Base64 변환기 입력',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': '텍스트',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64 변환기 입력',
+  'tools.base64.result.aria': 'Base64 변환기 출력',
+  'tools.base64.placeholder.encode':
     '입력하거나 붙여넣으세요 — UTF-8, 이모지, JWT 세그먼트. 모두 깔끔하게 왕복합니다.',
-  'tools.base64.output.label': '출력',
-  'tools.base64.output.aria': 'Base64 변환기 출력',
+  'tools.base64.placeholder.decode':
+    'base64 문자열을 붙여넣으세요 — JWT 세그먼트와 URL 안전 변형 모두 디코딩됩니다.',
   'tools.base64.swap': '교환 ⇄',
   'tools.base64.copy': '복사',
+  'tools.base64.copied': '복사됨',
+  'tools.base64.paste': '붙여넣기',
+  'tools.base64.paste.aria': '클립보드에서 붙여넣기',
+  'tools.base64.pasted': '붙여넣음',
+  'tools.base64.chars': '{n}자',
   'tools.base64.lengths': '입력 {in}자 · 출력 {out}자',
+  'tools.base64.explainer.heading': 'Base64 작동 방식',
+  'tools.base64.explainer.intro':
+    'Base64는 임의의 바이트를 64개의 인쇄 가능한 ASCII 문자(A–Z, a–z, 0–9, + /)로 포장합니다. 바이너리가 텍스트 전용 경로 — JSON 필드, URL, 이메일 본문, HTTP 헤더 — 를 살아남게 하려고 존재합니다.',
+  'tools.base64.explainer.mechanic':
+    '3바이트(24비트)를 가져와 6비트씩 4그룹으로 자르고, 각 그룹을 알파벳에서 찾아 4개의 ASCII 문자로 내보냅니다. 끝의 `=`은 입력이 맞아떨어지지 않을 때 출력을 4의 배수로 맞추는 패딩입니다.',
+  'tools.base64.explainer.example.label': '단계별 예제 — "Cat" 인코딩',
+  'tools.base64.explainer.uses':
+    'HTTP Basic Auth(`Authorization: Basic …`), JWT 세그먼트, CSS/HTML의 `data:` URI, 이메일 첨부(MIME)에서 마주칩니다.',
+  'tools.base64.explainer.warning':
+    '암호화가 아닙니다. 인코딩된 문자열을 가진 누구나 다시 디코딩할 수 있습니다. base64는 운송 봉투로 다루고 비밀로 쓰지 마세요.',
+  'tools.base64.explainer.tryauth': 'Basic Auth 헬퍼 시도 →',
+  'tools.basicauth.mode.aria': '헤더 생성 또는 읽기',
+  'tools.basicauth.mode.encode': '생성',
+  'tools.basicauth.mode.decode': '읽기',
+  'tools.basicauth.username.label': '사용자명',
+  'tools.basicauth.username.aria': 'Basic auth 사용자명',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': '비밀번호',
+  'tools.basicauth.password.aria': 'Basic auth 비밀번호',
+  'tools.basicauth.password.placeholder': '열려라 참깨',
+  'tools.basicauth.password.show': '표시',
+  'tools.basicauth.password.hide': '숨김',
+  'tools.basicauth.header.label': 'Authorization 헤더',
+  'tools.basicauth.header.aria': 'HTTP Authorization 헤더 값',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': '헤더 복사',
+  'tools.basicauth.copy.username': '사용자명 복사',
+  'tools.basicauth.copy.password': '비밀번호 복사',
+  'tools.basicauth.paste.header': '헤더 붙여넣기',
+  'tools.basicauth.invalid':
+    '그 헤더를 해석할 수 없었습니다. `Basic <base64>` 형식인지, 디코딩된 페이로드의 사용자명과 비밀번호 사이에 `:`가 있는지 확인하세요.',
+  'tools.basicauth.intro':
+    'HTTP Basic 인증이 사용하는 `Authorization: Basic <base64>` 헤더를 생성하고 읽습니다. 모두 로컬에서 — 자격 증명이 브라우저를 떠나지 않습니다.',
 };
 
 const hi: Translations = {
@@ -652,6 +1179,8 @@ const hi: Translations = {
   'sidebar.foot.line2': 'Pratiyush द्वारा बनाया गया।',
   'topbar.theme.aria': 'थीम',
   'topbar.github.aria': 'GitHub रिपॉजिटरी',
+  'topbar.language.aria': 'भाषा',
+  'topbar.language.label': 'भाषा',
   'tool.placeholder.title': 'टूल अभी तक लागू नहीं किया गया',
   'tool.placeholder.body': 'टूल लॉजिक उपलब्ध; रेंडर लेयर लंबित।',
   'footer.privacy': 'गोपनीयता',
@@ -666,6 +1195,8 @@ const hi: Translations = {
     'कुछ टूट गया। वजह हमें भी पूरी तरह स्पष्ट नहीं है। रीलोड करना अक्सर मदद करता है।',
   'error.copy.failed':
     'क्लिपबोर्ड ने मना कर दिया। शायद अनुमति की बात है — ब्राउज़र देखें और फिर से कोशिश करें।',
+  'error.paste.failed':
+    'क्लिपबोर्ड चुप रहा। ब्राउज़र पेस्ट को परमिशन के पीछे रखते हैं — दे दीजिए, या ⌘/Ctrl-V से सीधा पेस्ट करें।',
   'error.parse.failed':
     'यह पूरी तरह सही नहीं लग रहा। फालतू वर्ण या गलत फॉर्मेट देखें और फिर कोशिश करें।',
   'error.back.home': '← होम पर वापस',
@@ -674,15 +1205,55 @@ const hi: Translations = {
   'tools.base64.mode.decode': 'डीकोड',
   'tools.base64.urlsafe.label': 'URL-सुरक्षित प्रकार (-_, बिना पैडिंग)',
   'tools.base64.urlsafe.aria': 'URL-सुरक्षित base64 वर्णमाला का उपयोग करें',
-  'tools.base64.input.label': 'इनपुट',
-  'tools.base64.input.aria': 'Base64 कनवर्टर इनपुट',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'पाठ',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64 कनवर्टर इनपुट',
+  'tools.base64.result.aria': 'Base64 कनवर्टर आउटपुट',
+  'tools.base64.placeholder.encode':
     'टाइप करें या पेस्ट करें — UTF-8, इमोजी, JWT सेगमेंट। सब साफ-सुथरे राउंड-ट्रिप करते हैं।',
-  'tools.base64.output.label': 'आउटपुट',
-  'tools.base64.output.aria': 'Base64 कनवर्टर आउटपुट',
+  'tools.base64.placeholder.decode':
+    'कोई base64 स्ट्रिंग पेस्ट करें — JWT सेगमेंट और URL-सुरक्षित वैरिएंट दोनों डिकोड होते हैं।',
   'tools.base64.swap': 'स्वैप ⇄',
   'tools.base64.copy': 'कॉपी',
+  'tools.base64.copied': 'कॉपी हुआ',
+  'tools.base64.paste': 'पेस्ट',
+  'tools.base64.paste.aria': 'क्लिपबोर्ड से पेस्ट करें',
+  'tools.base64.pasted': 'पेस्ट हुआ',
+  'tools.base64.chars': '{n} वर्ण',
   'tools.base64.lengths': 'इनपुट {in} वर्ण · आउटपुट {out} वर्ण',
+  'tools.base64.explainer.heading': 'Base64 कैसे काम करता है',
+  'tools.base64.explainer.intro':
+    'Base64 मनमाने बाइट्स को 64 प्रिंट करने योग्य ASCII वर्णों (A–Z, a–z, 0–9, + /) में पैक करता है। यह इसलिए है कि बाइनरी सिर्फ-टेक्स्ट चैनलों — JSON फ़ील्ड, URL, ईमेल बॉडी, HTTP हेडर — से बच निकले।',
+  'tools.base64.explainer.mechanic':
+    '3 बाइट (24 बिट) लो, 6-6 बिट के 4 समूहों में काटो, हर समूह को वर्णमाला में देखो, और 4 ASCII वर्ण निकालो। अंत में `=` तब लगता है जब इनपुट मेल नहीं खाता और आउटपुट को 4 के गुणक तक भरना होता है।',
+  'tools.base64.explainer.example.label': 'उदाहरण के साथ — "Cat" को एनकोड करना',
+  'tools.base64.explainer.uses':
+    'तुम इसे HTTP Basic Auth (`Authorization: Basic …`), JWT सेगमेंट, CSS/HTML में `data:` URI, और ईमेल अटैचमेंट (MIME) में देखोगे।',
+  'tools.base64.explainer.warning':
+    'यह एन्क्रिप्शन नहीं है। एनकोडेड स्ट्रिंग रखने वाला कोई भी इसे वापस डिकोड कर सकता है। base64 को परिवहन का लिफाफा मानो, राज़ नहीं।',
+  'tools.base64.explainer.tryauth': 'Basic Auth मददगार आज़माएँ →',
+  'tools.basicauth.mode.aria': 'हेडर बनाओ या पढ़ो',
+  'tools.basicauth.mode.encode': 'बनाओ',
+  'tools.basicauth.mode.decode': 'पढ़ो',
+  'tools.basicauth.username.label': 'उपयोगकर्ता नाम',
+  'tools.basicauth.username.aria': 'Basic auth के लिए उपयोगकर्ता नाम',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'पासवर्ड',
+  'tools.basicauth.password.aria': 'Basic auth के लिए पासवर्ड',
+  'tools.basicauth.password.placeholder': 'खुल जा सिम सिम',
+  'tools.basicauth.password.show': 'दिखाओ',
+  'tools.basicauth.password.hide': 'छिपाओ',
+  'tools.basicauth.header.label': 'Authorization हेडर',
+  'tools.basicauth.header.aria': 'HTTP Authorization हेडर का मान',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'हेडर कॉपी',
+  'tools.basicauth.copy.username': 'उपयोगकर्ता कॉपी',
+  'tools.basicauth.copy.password': 'पासवर्ड कॉपी',
+  'tools.basicauth.paste.header': 'हेडर पेस्ट',
+  'tools.basicauth.invalid':
+    'वह हेडर पार्स नहीं हुआ। जाँचो कि वह `Basic <base64>` जैसा दिखता है और डिकोड की गई सामग्री में उपयोगकर्ता नाम और पासवर्ड के बीच `:` है।',
+  'tools.basicauth.intro':
+    'HTTP Basic प्रमाणीकरण का `Authorization: Basic <base64>` हेडर बनाता और पढ़ता है। सब डिवाइस पर — क्रेडेंशियल ब्राउज़र से बाहर नहीं जाते।',
 };
 
 const ar: Translations = {
@@ -704,6 +1275,8 @@ const ar: Translations = {
   'sidebar.foot.line2': 'صنع بواسطة Pratiyush.',
   'topbar.theme.aria': 'السمة',
   'topbar.github.aria': 'مستودع GitHub',
+  'topbar.language.aria': 'اللغة',
+  'topbar.language.label': 'اللغة',
   'tool.placeholder.title': 'الأداة لم تُنفّذ بعد',
   'tool.placeholder.body': 'منطق الأداة متاح؛ طبقة العرض في الانتظار.',
   'footer.privacy': 'الخصوصية',
@@ -717,6 +1290,8 @@ const ar: Translations = {
   'error.unknown': 'شيء ما تعطّل. السبب ليس واضحًا تمامًا حتى لنا. إعادة التحميل تفي بالغرض عادةً.',
   'error.copy.failed':
     'الحافظة رفضت. على الأرجح مسألة أذونات — تحقق من إعدادات المتصفح وحاول مرة أخرى.',
+  'error.paste.failed':
+    'الحافظة لزمت الصمت. تحجب المتصفحات اللصق خلف إذن — امنحه، أو الصق مباشرة بـ ⌘/Ctrl-V في الحقل.',
   'error.parse.failed': 'هذا لا يبدو صحيحًا تمامًا. تحقق من حروف زائدة أو تنسيق خاطئ وحاول مجددًا.',
   'error.back.home': '← العودة إلى الرئيسية',
   'tools.base64.mode.aria': 'ترميز أو فك ترميز',
@@ -724,15 +1299,55 @@ const ar: Translations = {
   'tools.base64.mode.decode': 'فك ترميز',
   'tools.base64.urlsafe.label': 'المتغير الآمن للروابط (-_، بدون حشو)',
   'tools.base64.urlsafe.aria': 'استخدم الأبجدية base64 الآمنة للروابط',
-  'tools.base64.input.label': 'الإدخال',
-  'tools.base64.input.aria': 'إدخال محول base64',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'نص',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'إدخال محول base64',
+  'tools.base64.result.aria': 'إخراج محول base64',
+  'tools.base64.placeholder.encode':
     'اكتب أو الصق — UTF-8، الإيموجي، أجزاء JWT. كلها تذهب وتعود نظيفة.',
-  'tools.base64.output.label': 'الإخراج',
-  'tools.base64.output.aria': 'إخراج محول base64',
+  'tools.base64.placeholder.decode':
+    'الصق سلسلة base64 — قطع JWT والمتغيرات الآمنة للروابط جميعها تُفك ترميزها.',
   'tools.base64.swap': 'تبديل ⇄',
   'tools.base64.copy': 'نسخ',
+  'tools.base64.copied': 'تم النسخ',
+  'tools.base64.paste': 'لصق',
+  'tools.base64.paste.aria': 'اللصق من الحافظة',
+  'tools.base64.pasted': 'تم اللصق',
+  'tools.base64.chars': '{n} حرف',
   'tools.base64.lengths': '{in} حرف إدخال · {out} حرف إخراج',
+  'tools.base64.explainer.heading': 'كيف يعمل Base64',
+  'tools.base64.explainer.intro':
+    'يُحزّم Base64 بايتات اعتباطية في 64 محرفًا ASCII قابلًا للطباعة (A–Z، a–z، 0–9، + /). وُجد ليبقى الثنائي حيًا في القنوات النصية فقط: حقول JSON، الروابط، أجساد البريد، ترويسات HTTP.',
+  'tools.base64.explainer.mechanic':
+    'خذ 3 بايتات (24 بِتًّا)، قسّمها إلى 4 مجموعات من 6 بِتّ لكل منها، ابحث عن كل مجموعة في الأبجدية، وأصدر 4 محارف ASCII. علامة `=` في النهاية تكمل الناتج إلى مضاعَف 4 عندما لا تُحاذي المُدخلات.',
+  'tools.base64.explainer.example.label': 'مثال محلول — تشفير "Cat"',
+  'tools.base64.explainer.uses':
+    'ستراه في HTTP Basic Auth (`Authorization: Basic …`)، وفي قطع JWT، وفي روابط `data:` ضمن CSS/HTML، وفي مرفقات البريد (MIME).',
+  'tools.base64.explainer.warning':
+    'ليس تشفيرًا. أيّ شخص بحوزته السلسلة المُشفّرة يستطيع فكّها. عامل base64 كمظروف نقل، ولا تستخدمه سرًّا.',
+  'tools.base64.explainer.tryauth': 'جرّب مساعد Basic Auth →',
+  'tools.basicauth.mode.aria': 'بناء أو قراءة الترويسة',
+  'tools.basicauth.mode.encode': 'بناء',
+  'tools.basicauth.mode.decode': 'قراءة',
+  'tools.basicauth.username.label': 'اسم المستخدم',
+  'tools.basicauth.username.aria': 'اسم المستخدم لـ Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'كلمة المرور',
+  'tools.basicauth.password.aria': 'كلمة المرور لـ Basic auth',
+  'tools.basicauth.password.placeholder': 'افتح يا سمسم',
+  'tools.basicauth.password.show': 'إظهار',
+  'tools.basicauth.password.hide': 'إخفاء',
+  'tools.basicauth.header.label': 'ترويسة Authorization',
+  'tools.basicauth.header.aria': 'قيمة ترويسة HTTP Authorization',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'انسخ الترويسة',
+  'tools.basicauth.copy.username': 'انسخ المستخدم',
+  'tools.basicauth.copy.password': 'انسخ كلمة المرور',
+  'tools.basicauth.paste.header': 'الصق الترويسة',
+  'tools.basicauth.invalid':
+    'هذه الترويسة لم تُحلّل. تأكّد أن صيغتها `Basic <base64>` وأن المحتوى المفكوك يحوي `:` بين المستخدم وكلمة المرور.',
+  'tools.basicauth.intro':
+    'يُنشئ ويقرأ ترويسة `Authorization: Basic <base64>` التي يستخدمها مصادقة HTTP Basic. كلّه محلي — لا تغادر بياناتك المتصفّح.',
 };
 
 export const ALL_TRANSLATIONS: Record<string, Translations> = {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -43,6 +43,22 @@ const en: Translations = {
   'error.parse.failed':
     "That doesn't look quite right. Check for stray characters or the wrong format and try again.",
   'error.back.home': '← Back to home',
+
+  // Day 1 — base64-string-converter
+  'tools.base64.mode.aria': 'Encode or decode',
+  'tools.base64.mode.encode': 'Encode',
+  'tools.base64.mode.decode': 'Decode',
+  'tools.base64.urlsafe.label': 'URL-safe variant (-_, no padding)',
+  'tools.base64.urlsafe.aria': 'Use URL-safe base64 alphabet',
+  'tools.base64.input.label': 'Input',
+  'tools.base64.input.aria': 'Base64 converter input',
+  'tools.base64.input.placeholder':
+    'Type or paste — UTF-8, emoji, JWT segments. All round-trip cleanly.',
+  'tools.base64.output.label': 'Output',
+  'tools.base64.output.aria': 'Base64 converter output',
+  'tools.base64.swap': 'Swap ⇄',
+  'tools.base64.copy': 'Copy',
+  'tools.base64.lengths': '{in} chars in · {out} chars out',
 };
 
 export default en;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -23,6 +23,8 @@ const en: Translations = {
 
   'topbar.theme.aria': 'Theme',
   'topbar.github.aria': 'GitHub repository',
+  'topbar.language.aria': 'Language',
+  'topbar.language.label': 'Language',
 
   'tool.placeholder.title': 'Tool not yet implemented',
   'tool.placeholder.body': 'Tool logic available; render layer pending.',
@@ -40,6 +42,8 @@ const en: Translations = {
     'Something broke. The cause is not entirely clear, even to us. A reload usually helps.',
   'error.copy.failed':
     'Clipboard said no. Probably a permissions thing — check your browser settings and try once more.',
+  'error.paste.failed':
+    'Clipboard kept its mouth shut. Browsers gate paste behind a permission — grant it, or paste with ⌘/Ctrl-V into the field.',
   'error.parse.failed':
     "That doesn't look quite right. Check for stray characters or the wrong format and try again.",
   'error.back.home': '← Back to home',
@@ -50,15 +54,56 @@ const en: Translations = {
   'tools.base64.mode.decode': 'Decode',
   'tools.base64.urlsafe.label': 'URL-safe variant (-_, no padding)',
   'tools.base64.urlsafe.aria': 'Use URL-safe base64 alphabet',
-  'tools.base64.input.label': 'Input',
-  'tools.base64.input.aria': 'Base64 converter input',
-  'tools.base64.input.placeholder':
+  'tools.base64.label.text': 'Text',
+  'tools.base64.label.base64': 'Base64',
+  'tools.base64.source.aria': 'Base64 converter input',
+  'tools.base64.result.aria': 'Base64 converter output',
+  'tools.base64.placeholder.encode':
     'Type or paste — UTF-8, emoji, JWT segments. All round-trip cleanly.',
-  'tools.base64.output.label': 'Output',
-  'tools.base64.output.aria': 'Base64 converter output',
+  'tools.base64.placeholder.decode':
+    'Paste a base64 string — JWT segments and URL-safe variants both decode.',
   'tools.base64.swap': 'Swap ⇄',
   'tools.base64.copy': 'Copy',
+  'tools.base64.copied': 'Copied',
+  'tools.base64.paste': 'Paste',
+  'tools.base64.paste.aria': 'Paste from clipboard',
+  'tools.base64.pasted': 'Pasted',
+  'tools.base64.chars': '{n} chars',
   'tools.base64.lengths': '{in} chars in · {out} chars out',
+  'tools.base64.explainer.heading': 'How Base64 works',
+  'tools.base64.explainer.intro':
+    'Base64 packs arbitrary bytes into 64 printable ASCII characters (A–Z, a–z, 0–9, + /). It exists so binary survives text-only channels — JSON fields, URLs, email bodies, HTTP headers.',
+  'tools.base64.explainer.mechanic':
+    'Take 3 bytes (24 bits), slice into 4 groups of 6 bits, look each group up in the alphabet, emit 4 ASCII characters. Trailing `=` pads the output to a multiple of 4 when the input does not align.',
+  'tools.base64.explainer.example.label': 'Worked example — encoding "Cat"',
+  'tools.base64.explainer.uses':
+    'You will see it in HTTP Basic Auth (`Authorization: Basic …`), JWT segments, `data:` URIs in CSS/HTML, and email attachments (MIME).',
+  'tools.base64.explainer.warning':
+    'Not encryption. Anyone with the encoded string can decode it back. Treat base64 as an envelope for transport, never as a secret.',
+  'tools.base64.explainer.tryauth': 'Try the Basic Auth helper →',
+
+  'tools.basicauth.mode.aria': 'Build header or read header',
+  'tools.basicauth.mode.encode': 'Build',
+  'tools.basicauth.mode.decode': 'Read',
+  'tools.basicauth.username.label': 'Username',
+  'tools.basicauth.username.aria': 'Username for Basic auth',
+  'tools.basicauth.username.placeholder': 'aladdin',
+  'tools.basicauth.password.label': 'Password',
+  'tools.basicauth.password.aria': 'Password for Basic auth',
+  'tools.basicauth.password.placeholder': 'open sesame',
+  'tools.basicauth.password.show': 'Show',
+  'tools.basicauth.password.hide': 'Hide',
+  'tools.basicauth.header.label': 'Authorization header',
+  'tools.basicauth.header.aria': 'HTTP Authorization header value',
+  'tools.basicauth.header.placeholder': 'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+  'tools.basicauth.copy.header': 'Copy header',
+  'tools.basicauth.copy.username': 'Copy username',
+  'tools.basicauth.copy.password': 'Copy password',
+  'tools.basicauth.paste.header': 'Paste header',
+  'tools.basicauth.invalid':
+    'That header did not parse. Make sure it looks like `Basic <base64>` and the decoded payload contains a `:` between username and password.',
+  'tools.basicauth.intro':
+    'Builds and reads the `Authorization: Basic <base64>` header used by HTTP Basic Authentication. All on-device — credentials never leave your browser.',
 };
 
 export default en;

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,16 +1,22 @@
+import { ALL_TRANSLATIONS } from '../../scripts/translations-data';
 import type { Translations } from './types';
 import en from './en';
 
 /**
  * Locale registry. The 15 locale codes below are recognized — auto-detected
  * from `navigator.language` and stored when chosen. Real translations come
- * from one of:
- *   1. `src/locales/_synced/<code>.json` — fetched by `pnpm sync-i18n` from
- *      Tolgee. Vite's `import.meta.glob` picks them up at build time, so the
- *      deployed app contains them as static assets and never calls Tolgee.
- *   2. `src/locales/<code>.ts` — hand-rolled fallback (only `en` today).
- *
- * Lookup order: synced JSON → hand-rolled → English.
+ * from three layered sources, lowest priority first:
+ *   1. English fallback (`src/locales/en.ts`) — guaranteed to have every key,
+ *      so a brand-new key never surfaces as a raw string to the user.
+ *   2. Hand-authored translations (`scripts/translations-data.ts`) — written
+ *      in code, type-checked against {@link Translations}. These ship in the
+ *      bundle and make the runtime language switcher actually swap strings,
+ *      even before a Tolgee round-trip has populated the synced JSON.
+ *   3. Tolgee-synced JSON (`src/locales/_synced/<code>.json`) — fetched by
+ *      `pnpm sync-i18n`. Vite's `import.meta.glob` picks them up at build
+ *      time, so the deployed app contains them as static assets and never
+ *      calls Tolgee. When present, these win because translators may have
+ *      refined the authored text.
  */
 
 export const LOCALES = [
@@ -44,13 +50,12 @@ const synced = import.meta.glob<Record<string, string>>('./_synced/*.json', {
 });
 
 function buildTable(code: LocaleCode): Translations {
+  const authored = ALL_TRANSLATIONS[code];
   const synced_ = synced[`./_synced/${code}.json`];
-  if (synced_) {
-    // Merge English defaults with synced overrides so missing keys never
-    // surface as raw key strings to the user.
-    return { ...en, ...synced_ };
-  }
-  return en;
+  // Layered merge: en (every key, English) ← authored (full native, in code)
+  // ← synced (Tolgee-refined). Missing keys fall back gracefully through
+  // each layer instead of surfacing as raw key strings.
+  return { ...en, ...(authored ?? {}), ...(synced_ ?? {}) };
 }
 
 const LOCALE_TABLES: Record<LocaleCode, Translations> = Object.fromEntries(

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -45,6 +45,21 @@ export interface Translations {
   'error.copy.failed': string;
   'error.parse.failed': string;
   'error.back.home': string;
+
+  // Day 1 — base64-string-converter
+  'tools.base64.mode.aria': string;
+  'tools.base64.mode.encode': string;
+  'tools.base64.mode.decode': string;
+  'tools.base64.urlsafe.label': string;
+  'tools.base64.urlsafe.aria': string;
+  'tools.base64.input.label': string;
+  'tools.base64.input.aria': string;
+  'tools.base64.input.placeholder': string;
+  'tools.base64.output.label': string;
+  'tools.base64.output.aria': string;
+  'tools.base64.swap': string;
+  'tools.base64.copy': string;
+  'tools.base64.lengths': string;
 }
 
 export type TranslationKey = keyof Translations;

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -43,6 +43,7 @@ export interface Translations {
   'error.404.body': string;
   'error.unknown': string;
   'error.copy.failed': string;
+  'error.paste.failed': string;
   'error.parse.failed': string;
   'error.back.home': string;
 
@@ -52,14 +53,61 @@ export interface Translations {
   'tools.base64.mode.decode': string;
   'tools.base64.urlsafe.label': string;
   'tools.base64.urlsafe.aria': string;
-  'tools.base64.input.label': string;
-  'tools.base64.input.aria': string;
-  'tools.base64.input.placeholder': string;
-  'tools.base64.output.label': string;
-  'tools.base64.output.aria': string;
+  // Pane labels are format-aware: in encode mode the source is plain text and
+  // the result is base64; decode mode swaps them. Two keys instead of generic
+  // "input/output" so the visible header tells the user what content lives
+  // there. ARIA labels stay role-oriented for assistive tech consumers.
+  'tools.base64.label.text': string;
+  'tools.base64.label.base64': string;
+  'tools.base64.source.aria': string;
+  'tools.base64.result.aria': string;
+  'tools.base64.placeholder.encode': string;
+  'tools.base64.placeholder.decode': string;
   'tools.base64.swap': string;
   'tools.base64.copy': string;
+  'tools.base64.copied': string;
+  'tools.base64.paste': string;
+  'tools.base64.paste.aria': string;
+  'tools.base64.pasted': string;
+  'tools.base64.chars': string;
   'tools.base64.lengths': string;
+  // Explainer — concise blog-style section that lives below the workspace.
+  // Bodies are deliberately short to keep 15-locale translation tractable.
+  'tools.base64.explainer.heading': string;
+  'tools.base64.explainer.intro': string;
+  'tools.base64.explainer.mechanic': string;
+  'tools.base64.explainer.example.label': string;
+  'tools.base64.explainer.uses': string;
+  'tools.base64.explainer.warning': string;
+  'tools.base64.explainer.tryauth': string;
+
+  // Day 2 — base64-basic-auth (HTTP Basic Authorization header builder)
+  'tools.basicauth.mode.aria': string;
+  'tools.basicauth.mode.encode': string;
+  'tools.basicauth.mode.decode': string;
+  'tools.basicauth.username.label': string;
+  'tools.basicauth.username.aria': string;
+  'tools.basicauth.username.placeholder': string;
+  'tools.basicauth.password.label': string;
+  'tools.basicauth.password.aria': string;
+  'tools.basicauth.password.placeholder': string;
+  'tools.basicauth.password.show': string;
+  'tools.basicauth.password.hide': string;
+  'tools.basicauth.header.label': string;
+  'tools.basicauth.header.aria': string;
+  'tools.basicauth.header.placeholder': string;
+  'tools.basicauth.copy.header': string;
+  'tools.basicauth.copy.username': string;
+  'tools.basicauth.copy.password': string;
+  'tools.basicauth.paste.header': string;
+  'tools.basicauth.invalid': string;
+  'tools.basicauth.intro': string;
+
+  // Topbar language switcher — overrides browser default for the session;
+  // the override is held in memory only, so a hard reload reverts to the
+  // detected/persisted locale.
+  'topbar.language.aria': string;
+  'topbar.language.label': string;
 }
 
 export type TranslationKey = keyof Translations;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,35 +1,57 @@
 import './style.css';
-import { initI18n, translate } from './lib/i18n';
+import { initI18n, onLocaleChange, translate } from './lib/i18n';
 import { initTheme } from './lib/theme';
 import { TOOLS } from './tools/index';
 import { home } from './ui/home';
 import { illustration } from './ui/illustrations';
-import { layout } from './ui/layout';
+import { layout, type LayoutHandle } from './ui/layout';
 
 const REPO_URL = 'https://github.com/Pratiyush/developer-tools';
 const REDIRECT_KEY = 'dt.deep-redirect';
 
-const host = document.querySelector<HTMLElement>('#app');
-if (!host) {
+const hostMaybe = document.querySelector<HTMLElement>('#app');
+if (!hostMaybe) {
   throw new Error('Mount target #app not found');
 }
+const host: HTMLElement = hostMaybe;
 
 initI18n();
 const theme = initTheme();
 
-const ui = layout({
-  host,
-  initialTheme: theme,
-  tools: TOOLS,
-  repoUrl: REPO_URL,
-  onSelectTool: (id) => {
-    if (id) routeTo(id);
-    else routeTo(null);
-  },
+/** Active tool's dispose handle; cleared on every route change. Declared
+ *  before {@link buildLayout} so the function body can reference it without
+ *  hitting a temporal-dead-zone ReferenceError on initial mount. */
+let activeToolDispose: (() => void) | null = null;
+
+let ui: LayoutHandle = buildLayout();
+
+onLocaleChange(() => {
+  // Tear down the previous layout (also disposes tool/topbar/sidebar).
+  ui.dispose();
+  ui = buildLayout();
+  routeTo(readHash());
 });
 
-/** Active tool's dispose handle; cleared on every route change. */
-let activeToolDispose: (() => void) | null = null;
+/** Rebuilds the entire layout with the current locale's translations.
+ *  Used on first paint and again when the topbar language switcher fires —
+ *  every component captures its translations at construction time, so a
+ *  full re-mount is the simplest way to reflect a runtime locale change. */
+function buildLayout(): LayoutHandle {
+  if (activeToolDispose) {
+    activeToolDispose();
+    activeToolDispose = null;
+  }
+  return layout({
+    host,
+    initialTheme: theme,
+    tools: TOOLS,
+    repoUrl: REPO_URL,
+    onSelectTool: (id) => {
+      if (id) routeTo(id);
+      else routeTo(null);
+    },
+  });
+}
 
 function routeTo(id: string | null): void {
   // Tear down any previously mounted tool first.

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,16 @@ const ui = layout({
   },
 });
 
+/** Active tool's dispose handle; cleared on every route change. */
+let activeToolDispose: (() => void) | null = null;
+
 function routeTo(id: string | null): void {
+  // Tear down any previously mounted tool first.
+  if (activeToolDispose) {
+    activeToolDispose();
+    activeToolDispose = null;
+  }
+
   const homeCrumb = translate('nav.home');
   if (id === null) {
     ui.setView(home(TOOLS), [homeCrumb]);
@@ -41,11 +50,73 @@ function routeTo(id: string | null): void {
     ui.sidebar.setActive(null);
     return;
   }
-  const placeholder = document.createElement('div');
-  placeholder.classList.add('dt-home__empty');
-  placeholder.textContent = `${tool.name} — ${translate('tool.placeholder.body')}`;
-  ui.setView(placeholder, [homeCrumb, formatCategory(tool.category), tool.name]);
+
+  // Real mount. Parse current URL state, render, and wire change events.
+  // The registry stores tools with their state generic widened to `never`,
+  // so we treat each tool as a self-contained renderer that owns its own
+  // state shape. The render call passes the current URL-derived state back
+  // to itself; the only contract the registry cares about is dispose().
+  const search = new URLSearchParams(window.location.search);
+  const hashParams = parseToolHash();
+  const wrap = document.createElement('div');
+  wrap.classList.add('dt-tool-host');
+
+  // Each tool's render hook may also accept an optional onStateChange callback
+  // we wire to URL writes. We coerce through unknown — the registry intentionally
+  // erases per-tool state so the dispatcher doesn't need to know each shape.
+  const initial = (
+    tool as unknown as { parseParams: (s: URLSearchParams, h: URLSearchParams) => unknown }
+  ).parseParams(search, hashParams);
+  const renderFn = (
+    tool as unknown as {
+      render: (
+        host: HTMLElement,
+        state: unknown,
+        opts?: { onStateChange?: (next: unknown) => void },
+      ) => { dispose(): void };
+    }
+  ).render;
+  const serialize = (
+    tool as unknown as {
+      serializeParams: (state: unknown) => { search: URLSearchParams; hash: URLSearchParams };
+    }
+  ).serializeParams;
+
+  const handle = renderFn(wrap, initial, {
+    onStateChange: (next) => {
+      writeToolUrl(tool.id, serialize(next));
+    },
+  });
+  activeToolDispose = (): void => {
+    handle.dispose();
+  };
+  ui.setView(wrap, [homeCrumb, formatCategory(tool.category), tool.name]);
   ui.sidebar.setActive(tool.id);
+}
+
+/** The router uses `#/<slug>` for navigation; tool state-hash is stored as
+ *  a separate `?...` after a second `?` appended to the slug. We strip the
+ *  navigation prefix and reparse the rest. */
+function parseToolHash(): URLSearchParams {
+  const raw = window.location.hash;
+  if (!raw.startsWith('#/')) return new URLSearchParams();
+  const idx = raw.indexOf('?');
+  if (idx === -1) return new URLSearchParams();
+  return new URLSearchParams(raw.slice(idx + 1));
+}
+
+/** Writes `?<search>` and `#/<slug>?<hash>` back to the URL without
+ *  triggering the hashchange listener. */
+function writeToolUrl(
+  slug: string,
+  parts: { search: URLSearchParams; hash: URLSearchParams },
+): void {
+  const searchString = parts.search.toString();
+  const hashString = parts.hash.toString();
+  const newSearch = searchString ? `?${searchString}` : '';
+  const newHash = hashString ? `#/${slug}?${hashString}` : `#/${slug}`;
+  const target = `${window.location.pathname}${newSearch}${newHash}`;
+  window.history.replaceState(null, '', target);
 }
 
 function notFound(badId: string): HTMLElement {
@@ -82,7 +153,10 @@ function formatCategory(slug: string): string {
 function readHash(): string | null {
   const hash = window.location.hash;
   if (!hash.startsWith('#/')) return null;
-  const slug = hash.slice(2);
+  // Strip any tool-state query (`?...`) before extracting the slug.
+  const slugAndQuery = hash.slice(2);
+  const idx = slugAndQuery.indexOf('?');
+  const slug = idx === -1 ? slugAndQuery : slugAndQuery.slice(0, idx);
   return slug.length === 0 ? null : slug;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1084,8 +1084,11 @@ select {
 }
 
 .dt-base64__copy {
-  font-size: var(--fs-sm);
-  font-weight: 600;
+  /* axe "large text" threshold (3:1) is 14px bold or 18.66px regular —
+     14px @ 700 lets the accent/accent-fg combo pass on Linear/Vercel where
+     the contrast ratio sits between 3:1 and 4.5:1. */
+  font-size: var(--fs-base);
+  font-weight: 700;
   padding: var(--sp-2) var(--sp-4);
   background: var(--accent);
   color: var(--accent-fg);
@@ -1116,11 +1119,14 @@ select {
 
 /* ─── Paste button on the input pane (subtler than the primary copy CTA) ─── */
 .dt-base64__paste {
-  font-size: var(--fs-sm);
-  font-weight: 600;
+  /* Match the copy button's 14px@700 so axe sees the same large-text class.
+     Background uses surface tones rather than accent — paste is a secondary
+     action, so it stays understated next to the primary copy. */
+  font-size: var(--fs-base);
+  font-weight: 700;
   padding: var(--sp-2) var(--sp-4);
   background: var(--bg-surface-2);
-  color: var(--fg-default);
+  color: var(--fg-strong);
   border: var(--border-w) solid var(--line);
   border-radius: var(--radius-pill);
   cursor: pointer;
@@ -1281,8 +1287,9 @@ select {
   background: var(--accent);
   color: var(--accent-fg);
   border-radius: var(--radius-pill);
-  font-weight: 600;
-  font-size: var(--fs-sm);
+  /* 14px @ 700 → axe-large-text class so accent/accent-fg passes 3:1. */
+  font-weight: 700;
+  font-size: var(--fs-base);
   transition:
     filter var(--anim-fast),
     transform 80ms ease;

--- a/src/style.css
+++ b/src/style.css
@@ -480,7 +480,7 @@ select {
   font-size: var(--fs-sm);
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: var(--fg-faint);
+  color: var(--fg-muted);
   font-weight: 600;
   margin: var(--sp-8) 0 var(--sp-3);
 }
@@ -637,8 +637,9 @@ select {
 
 .dt-card__num {
   font-family: var(--font-mono);
-  font-size: var(--fs-xs);
-  color: var(--fg-faint);
+  font-size: var(--fs-sm);
+  color: var(--fg-muted);
+  font-weight: 600;
 }
 
 .dt-card__title {

--- a/src/style.css
+++ b/src/style.css
@@ -1084,12 +1084,13 @@ select {
 }
 
 .dt-base64__copy {
-  /* axe "large text" threshold (3:1) is 14px bold or 18.66px regular —
-     14px @ 700 lets the accent/accent-fg combo pass on Linear/Vercel where
-     the contrast ratio sits between 3:1 and 4.5:1. */
-  font-size: var(--fs-base);
+  /* axe "large text" threshold (3:1) is 14pt = 18.66px bold or 18pt = 24px
+     regular. 20px @ 700 clears 14pt bold so accent/accent-fg passes on
+     Linear (3.95:1) and Vercel (3.34:1) themes — matches the precedent set
+     by the brand-mark fix. */
+  font-size: 20px;
   font-weight: 700;
-  padding: var(--sp-2) var(--sp-4);
+  padding: var(--sp-2) var(--sp-5);
   background: var(--accent);
   color: var(--accent-fg);
   border: none;
@@ -1119,12 +1120,13 @@ select {
 
 /* ─── Paste button on the input pane (subtler than the primary copy CTA) ─── */
 .dt-base64__paste {
-  /* Match the copy button's 14px@700 so axe sees the same large-text class.
+  /* Match the copy button's 20px@700 so the two pills line up visually.
      Background uses surface tones rather than accent — paste is a secondary
-     action, so it stays understated next to the primary copy. */
-  font-size: var(--fs-base);
+     action, so it stays understated next to the primary copy CTA. The
+     surface/fg-strong combo always passes contrast in every theme. */
+  font-size: 20px;
   font-weight: 700;
-  padding: var(--sp-2) var(--sp-4);
+  padding: var(--sp-2) var(--sp-5);
   background: var(--bg-surface-2);
   color: var(--fg-strong);
   border: var(--border-w) solid var(--line);
@@ -1283,13 +1285,15 @@ select {
 .dt-base64__explainer-cta {
   align-self: flex-start;
   margin-top: var(--sp-2);
-  padding: var(--sp-2) var(--sp-4);
+  padding: var(--sp-3) var(--sp-5);
   background: var(--accent);
   color: var(--accent-fg);
   border-radius: var(--radius-pill);
-  /* 14px @ 700 → axe-large-text class so accent/accent-fg passes 3:1. */
+  /* 20px @ 700 clears the 14pt-bold large-text threshold so accent/accent-fg
+     passes the 3:1 ratio on Linear and Vercel themes (where the raw
+     accent/accent-fg combo sits at 3.95 and 3.34 respectively). */
   font-weight: 700;
-  font-size: var(--fs-base);
+  font-size: 20px;
   transition:
     filter var(--anim-fast),
     transform 80ms ease;

--- a/src/style.css
+++ b/src/style.css
@@ -603,10 +603,10 @@ select {
 }
 
 .dt-panel__label {
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: var(--fg-faint);
+  color: var(--fg-muted);
   font-weight: 600;
   margin-bottom: var(--sp-2);
   display: block;

--- a/src/style.css
+++ b/src/style.css
@@ -967,11 +967,15 @@ select {
 }
 
 .dt-base64__switch-input {
+  /* Visually hidden but still in the layout flow at the label's origin so
+     keyboard focus and Playwright's .check() can find and activate it.
+     pointer-events stays default — removing it would break the click
+     forwarding from <label> to the underlying checkbox. */
   position: absolute;
   opacity: 0;
   width: 1px;
   height: 1px;
-  pointer-events: none;
+  margin: 0;
 }
 
 .dt-base64__switch-visual {
@@ -982,6 +986,9 @@ select {
   position: relative;
   transition: background var(--anim-fast);
   flex-shrink: 0;
+  /* Decorative — let clicks pass through to the wrapping <label> so the
+     native click→input forwarding (and Playwright's .check()) work. */
+  pointer-events: none;
 }
 
 .dt-base64__switch-visual::after {
@@ -1322,6 +1329,15 @@ select {
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
+}
+
+.dt-basicauth__heading {
+  margin: 0;
+  font-family: var(--font-head);
+  font-size: var(--fs-xl);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fg-strong);
 }
 
 .dt-basicauth__intro {

--- a/src/style.css
+++ b/src/style.css
@@ -826,3 +826,264 @@ select {
   color: var(--accent);
   border-color: var(--accent);
 }
+
+/* ─── Day 1: base64-string-converter (Claude-style two-pane) ─── */
+
+.dt-base64 {
+  display: grid;
+  gap: var(--sp-4);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--sp-4) 0;
+}
+
+.dt-base64__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-4);
+  flex-wrap: wrap;
+}
+
+/* ─── Segmented mode tabs (encode | decode) ─── */
+.dt-base64__segmented {
+  display: inline-flex;
+  background: var(--bg-surface-2);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+  gap: 2px;
+}
+
+.dt-base64__tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: var(--sp-2) var(--sp-4);
+  font-family: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition:
+    background var(--anim-fast),
+    color var(--anim-fast);
+  min-width: 96px;
+}
+
+.dt-base64__tab:hover {
+  color: var(--fg-default);
+}
+
+.dt-base64__tab--active {
+  background: var(--bg-surface);
+  color: var(--fg-strong);
+  box-shadow: var(--shadow-1);
+}
+
+/* ─── URL-safe switch ─── */
+.dt-base64__switch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  cursor: pointer;
+  user-select: none;
+  font-size: var(--fs-sm);
+  color: var(--fg-muted);
+}
+
+.dt-base64__switch-input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+}
+
+.dt-base64__switch-visual {
+  width: 36px;
+  height: 20px;
+  background: var(--line-strong);
+  border-radius: var(--radius-pill);
+  position: relative;
+  transition: background var(--anim-fast);
+  flex-shrink: 0;
+}
+
+.dt-base64__switch-visual::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--bg-surface);
+  border-radius: 50%;
+  box-shadow: var(--shadow-1);
+  transition: transform var(--anim-fast);
+}
+
+.dt-base64__switch-input:checked + .dt-base64__switch-visual {
+  background: var(--accent);
+}
+
+.dt-base64__switch-input:checked + .dt-base64__switch-visual::after {
+  transform: translateX(16px);
+}
+
+.dt-base64__switch-input:focus-visible + .dt-base64__switch-visual {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.dt-base64__switch-label {
+  color: var(--fg-default);
+}
+
+/* ─── Two-pane workspace ─── */
+.dt-base64__workspace {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  gap: var(--sp-3);
+}
+
+.dt-base64__pane {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: var(--sp-2);
+  background: var(--bg-surface);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius);
+  padding: var(--sp-4);
+  box-shadow: var(--shadow-1);
+}
+
+.dt-base64__pane-body {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: var(--sp-3);
+  min-height: 0;
+}
+
+.dt-base64__textarea {
+  width: 100%;
+  min-height: 240px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: var(--fs-base);
+  line-height: 1.5;
+  padding: var(--sp-3);
+  background: var(--bg-app);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--fg-strong);
+  transition:
+    border-color var(--anim-fast),
+    box-shadow var(--anim-fast);
+}
+
+.dt-base64__textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.dt-base64__textarea--mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  letter-spacing: 0.01em;
+  word-break: break-all;
+}
+
+.dt-base64__pane-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+}
+
+.dt-base64__lengths {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--fg-muted);
+}
+
+.dt-base64__copy {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--accent);
+  color: var(--accent-fg);
+  border: none;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  transition:
+    background var(--anim-fast),
+    transform 80ms ease;
+}
+
+.dt-base64__copy:hover {
+  filter: brightness(1.1);
+}
+
+.dt-base64__copy:active {
+  transform: scale(0.97);
+}
+
+.dt-base64__copy.dt-copy--copied {
+  background: transparent;
+  color: var(--fg-strong);
+  border: var(--border-w) solid var(--line-strong);
+}
+
+/* ─── Swap button between panes ─── */
+.dt-base64__swap {
+  align-self: center;
+  appearance: none;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: var(--border-w) solid var(--line);
+  background: var(--bg-surface);
+  color: var(--fg-muted);
+  font-size: 22px;
+  font-weight: 700;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  box-shadow: var(--shadow-2);
+  transition:
+    transform var(--anim-base),
+    color var(--anim-fast),
+    border-color var(--anim-fast);
+}
+
+.dt-base64__swap:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  transform: rotate(180deg);
+}
+
+.dt-base64__swap:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ─── Mobile / tablet stack ─── */
+@media (max-width: 880px) {
+  .dt-base64__workspace {
+    grid-template-columns: 1fr;
+  }
+  .dt-base64__swap {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+  .dt-base64__swap:hover {
+    transform: rotate(270deg);
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -827,6 +827,79 @@ select {
   border-color: var(--accent);
 }
 
+/* ─── Paste button feedback ─── */
+
+.dt-paste {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  border: var(--border-w) solid var(--line);
+  background: var(--bg-surface);
+  color: var(--fg-muted);
+  transition:
+    background var(--anim-fast),
+    color var(--anim-fast);
+}
+
+.dt-paste:hover {
+  background: var(--bg-surface-hover);
+  color: var(--fg-strong);
+}
+
+.dt-paste--pasted {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ─── Topbar language switcher (flag + locale) ─── */
+
+.dt-language-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--fg-default);
+  border: var(--border-w) solid transparent;
+  transition:
+    background var(--anim-fast),
+    border-color var(--anim-fast),
+    color var(--anim-fast);
+}
+
+.dt-language-switcher:hover {
+  background: var(--bg-surface-hover);
+  border-color: var(--line);
+  color: var(--fg-strong);
+}
+
+.dt-language-switcher:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.dt-language-switcher__flag {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.dt-language-switcher__code {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+}
+
+.dt-language-switcher:hover .dt-language-switcher__code {
+  color: var(--fg-default);
+}
+
 /* ─── Day 1: base64-string-converter (Claude-style two-pane) ─── */
 
 .dt-base64 {
@@ -1041,6 +1114,46 @@ select {
   border: var(--border-w) solid var(--line-strong);
 }
 
+/* ─── Paste button on the input pane (subtler than the primary copy CTA) ─── */
+.dt-base64__paste {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--bg-surface-2);
+  color: var(--fg-default);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  transition:
+    background var(--anim-fast),
+    border-color var(--anim-fast),
+    color var(--anim-fast),
+    transform 80ms ease;
+}
+
+.dt-base64__paste:hover {
+  background: var(--bg-surface-hover);
+  border-color: var(--line-strong);
+  color: var(--fg-strong);
+}
+
+.dt-base64__paste:active {
+  transform: scale(0.97);
+}
+
+.dt-base64__paste:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.dt-base64__paste.dt-paste--pasted {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* ─── Swap button between panes ─── */
 .dt-base64__swap {
   align-self: center;
@@ -1085,5 +1198,228 @@ select {
   }
   .dt-base64__swap:hover {
     transform: rotate(270deg);
+  }
+}
+
+/* ─── Explainer / "how it works" block beneath the workspace ─── */
+.dt-base64__explainer {
+  margin-top: var(--sp-8);
+  padding: var(--sp-6) var(--sp-6);
+  background: var(--bg-surface);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-1);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.dt-base64__explainer-h {
+  margin: 0;
+  font-family: var(--font-head);
+  font-size: var(--fs-xl);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fg-strong);
+}
+
+.dt-base64__explainer-p {
+  margin: 0;
+  color: var(--fg-default);
+  line-height: var(--lh-base);
+  max-width: 72ch;
+}
+
+.dt-base64__explainer-p code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  padding: 0 4px;
+  background: var(--bg-surface-2);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--fg-strong);
+}
+
+.dt-base64__explainer-eg-label {
+  margin: var(--sp-2) 0 0;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--fg-muted);
+}
+
+.dt-base64__explainer-eg {
+  margin: 0;
+  padding: var(--sp-3) var(--sp-4);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: 1.7;
+  background: var(--bg-app);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--fg-strong);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.dt-base64__explainer-warn {
+  margin: 0;
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--bg-surface-2);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: var(--fg-default);
+  line-height: var(--lh-base);
+  max-width: 72ch;
+}
+
+.dt-base64__explainer-cta {
+  align-self: flex-start;
+  margin-top: var(--sp-2);
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: var(--radius-pill);
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  transition:
+    filter var(--anim-fast),
+    transform 80ms ease;
+}
+
+.dt-base64__explainer-cta:hover {
+  filter: brightness(1.1);
+  text-decoration: none;
+}
+
+.dt-base64__explainer-cta:active {
+  transform: scale(0.98);
+}
+
+/* ─── Day 2: base64-basic-auth ─── */
+
+.dt-basicauth {
+  display: grid;
+  gap: var(--sp-4);
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--sp-4) 0;
+}
+
+.dt-basicauth__top {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.dt-basicauth__intro {
+  margin: 0;
+  color: var(--fg-muted);
+  max-width: 72ch;
+  line-height: var(--lh-base);
+}
+
+.dt-basicauth__workspace {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-4);
+}
+
+.dt-basicauth__pane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  padding: var(--sp-4);
+}
+
+.dt-basicauth__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+
+.dt-basicauth__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.dt-basicauth__field-label {
+  font-size: var(--fs-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--fg-muted);
+  font-weight: 600;
+}
+
+.dt-basicauth__field-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.dt-basicauth__field-row > input {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+}
+
+.dt-basicauth__suffixwrap {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  flex-shrink: 0;
+}
+
+.dt-basicauth__reveal {
+  font-size: var(--fs-xs);
+  font-family: var(--font-mono);
+  padding: var(--sp-1) var(--sp-2);
+  border: var(--border-w) solid var(--line);
+  background: var(--bg-surface);
+  color: var(--fg-muted);
+  border-radius: var(--radius-sm);
+  transition:
+    background var(--anim-fast),
+    color var(--anim-fast);
+}
+
+.dt-basicauth__reveal:hover {
+  background: var(--bg-surface-hover);
+  color: var(--fg-strong);
+}
+
+.dt-basicauth__field-copy {
+  font-size: var(--fs-xs);
+  padding: var(--sp-1) var(--sp-2);
+}
+
+.dt-basicauth__header-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+}
+
+.dt-basicauth__foot-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.dt-basicauth__status {
+  font-size: var(--fs-xs);
+  color: var(--fg-muted);
+  line-height: var(--lh-base);
+  max-width: 60ch;
+}
+
+.dt-basicauth__status--err {
+  color: var(--accent);
+}
+
+@media (max-width: 880px) {
+  .dt-basicauth__workspace {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/tools/01-encoding/001-base64-string-converter/index.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/index.ts
@@ -1,0 +1,18 @@
+import type { ToolModule } from '../../../lib/types';
+import { render } from './render';
+import { DEFAULT_STATE, parseParams, serializeParams, type State } from './url-state';
+
+export const tool: ToolModule<State> = {
+  id: 'base64-string-converter',
+  number: 1,
+  category: '01-encoding',
+  name: 'Base64 string converter',
+  description:
+    'Encode and decode UTF-8 strings to base64. URL-safe variant for JWT segments. Hash-routed for sensitive paste.',
+  tags: ['base64', 'encoding', 'utf-8', 'url-safe', 'jwt'],
+  parseParams,
+  serializeParams,
+  render,
+};
+
+export { DEFAULT_STATE };

--- a/src/tools/01-encoding/001-base64-string-converter/logic.test.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/logic.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { base64ToText, isValidBase64, textToBase64 } from './logic';
+
+describe('textToBase64', () => {
+  it('encodes ASCII', () => {
+    expect(textToBase64('Hello')).toBe('SGVsbG8=');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(textToBase64('')).toBe('');
+  });
+
+  it('round-trips UTF-8 (CJK)', () => {
+    expect(textToBase64('日本語')).toBe('5pel5pys6Kqe');
+  });
+
+  it('round-trips emoji (surrogate pairs)', () => {
+    expect(textToBase64('😀')).toBe('8J+YgA==');
+  });
+
+  it('round-trips accented Latin', () => {
+    expect(textToBase64('café')).toBe('Y2Fmw6k=');
+  });
+
+  it('encodes URL-safe variant: standard "/" becomes "_", padding stripped', () => {
+    // "subjects?ids[]=1" produces `c3ViamVjdHM/aWRzW109MQ==` in standard.
+    // URL-safe replaces `/` with `_` and strips the `==` padding.
+    expect(textToBase64('subjects?ids[]=1')).toBe('c3ViamVjdHM/aWRzW109MQ==');
+    expect(textToBase64('subjects?ids[]=1', { makeUrlSafe: true })).toBe(
+      'c3ViamVjdHM_aWRzW109MQ',
+    );
+  });
+
+  it('strips padding in URL-safe mode', () => {
+    expect(textToBase64('Hello', { makeUrlSafe: true })).toBe('SGVsbG8');
+    expect(textToBase64('Hello!', { makeUrlSafe: true })).toBe('SGVsbG8h');
+  });
+
+  it('replaces + with - in URL-safe mode', () => {
+    // The 😀 emoji UTF-8 encodes to bytes that produce `+` in standard base64
+    // ("8J+YgA==" — note the `+` at index 2).
+    const inputProducingPlus = '😀';
+    const standard = textToBase64(inputProducingPlus);
+    const urlSafe = textToBase64(inputProducingPlus, { makeUrlSafe: true });
+    expect(standard).toContain('+');
+    expect(urlSafe).not.toContain('+');
+    expect(urlSafe).toContain('-');
+  });
+
+  it('replaces / with _ in URL-safe mode', () => {
+    const standard = textToBase64('subjects?ids[]=1');
+    const urlSafe = textToBase64('subjects?ids[]=1', { makeUrlSafe: true });
+    expect(standard).toContain('/');
+    expect(urlSafe).not.toContain('/');
+    expect(urlSafe).toContain('_');
+  });
+});
+
+describe('base64ToText', () => {
+  it('decodes ASCII', () => {
+    expect(base64ToText('SGVsbG8=')).toBe('Hello');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(base64ToText('')).toBe('');
+  });
+
+  it('round-trips UTF-8 (CJK)', () => {
+    expect(base64ToText('5pel5pys6Kqe')).toBe('日本語');
+  });
+
+  it('round-trips emoji', () => {
+    expect(base64ToText('8J+YgA==')).toBe('😀');
+  });
+
+  it('strips a data:...;base64, prefix', () => {
+    expect(base64ToText('data:text/plain;base64,SGVsbG8=')).toBe('Hello');
+    expect(base64ToText('data:image/png;base64,SGVsbG8=')).toBe('Hello');
+  });
+
+  it('trims whitespace', () => {
+    expect(base64ToText('  SGVsbG8=  \n')).toBe('Hello');
+  });
+
+  it('decodes URL-safe variant', () => {
+    expect(
+      base64ToText('c3ViamVjdHM_aWRzW109MQ', { makeUrlSafe: true }),
+    ).toBe('subjects?ids[]=1');
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => base64ToText('not_base64!!!')).toThrow('Incorrect base64 string');
+  });
+
+  it('rejects URL-safe input in standard mode', () => {
+    // The `_` character is URL-safe alphabet only.
+    expect(() => base64ToText('SGVsbG8_')).toThrow('Incorrect base64 string');
+  });
+});
+
+describe('round-trip', () => {
+  it.each([
+    'Hello, world!',
+    '日本語',
+    '😀🌍🚀',
+    'café au lait',
+    'Tom & Jerry',
+    'subjects?ids[]=1&ids[]=2',
+    'A very long string '.repeat(50),
+  ])('preserves %s through encode→decode', (input) => {
+    expect(base64ToText(textToBase64(input))).toBe(input);
+  });
+
+  it.each(['Hello', '日本語', 'subjects?ids[]=1'])(
+    'preserves %s through URL-safe encode→decode',
+    (input) => {
+      expect(
+        base64ToText(textToBase64(input, { makeUrlSafe: true }), { makeUrlSafe: true }),
+      ).toBe(input);
+    },
+  );
+});
+
+describe('isValidBase64', () => {
+  it('accepts valid standard base64', () => {
+    expect(isValidBase64('SGVsbG8=')).toBe(true);
+    expect(isValidBase64('5pel5pys6Kqe')).toBe(true);
+  });
+
+  it('accepts the empty string', () => {
+    expect(isValidBase64('')).toBe(true);
+  });
+
+  it('accepts whitespace-padded valid input', () => {
+    expect(isValidBase64('  SGVsbG8=  \n')).toBe(true);
+  });
+
+  it('rejects bare URL-safe characters in standard mode', () => {
+    expect(isValidBase64('SGVsbG8_')).toBe(false);
+    expect(isValidBase64('c3ViamVjdHM-')).toBe(false);
+  });
+
+  it('accepts URL-safe input only when makeUrlSafe=true', () => {
+    expect(isValidBase64('c3ViamVjdHM_aWRzW109MQ', { makeUrlSafe: true })).toBe(true);
+    expect(isValidBase64('c3ViamVjdHM_aWRzW109MQ')).toBe(false);
+  });
+
+  it('rejects non-multiple-of-4 length in standard mode', () => {
+    expect(isValidBase64('SGVsbG8')).toBe(false); // missing padding
+  });
+
+  it('rejects strings with non-base64 characters', () => {
+    expect(isValidBase64('Hello!')).toBe(false);
+    expect(isValidBase64('not base64')).toBe(false);
+    expect(isValidBase64('日本語')).toBe(false);
+  });
+});

--- a/src/tools/01-encoding/001-base64-string-converter/logic.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/logic.ts
@@ -1,0 +1,131 @@
+/**
+ * UTF-8-safe Base64 encoding/decoding with optional URL-safe variant.
+ *
+ * Why not raw `btoa` / `atob`?
+ *   `btoa` only handles Latin-1 — `btoa("日本語")` throws. We round-trip
+ *   through `TextEncoder` / `TextDecoder` so any UTF-8 string (CJK, emoji,
+ *   accented Latin) survives encode → decode unchanged.
+ *
+ * URL-safe variant (RFC 4648 §5):
+ *   - `+` → `-`, `/` → `_`
+ *   - padding (`=`) stripped
+ *   Common in JWT segments and URL fragments.
+ */
+
+export interface Base64Options {
+  /** Use the URL-safe alphabet. Default false. */
+  readonly makeUrlSafe?: boolean;
+}
+
+const STANDARD_ALPHABET = /^[A-Za-z0-9+/]*={0,2}$/;
+const URL_SAFE_ALPHABET = /^[A-Za-z0-9_-]*={0,2}$/;
+const DATA_URI_PREFIX = /^data:[^;]*;base64,/;
+
+/**
+ * Encode a UTF-8 string to Base64.
+ *
+ * @example
+ *   textToBase64("Hello")              // "SGVsbG8="
+ *   textToBase64("日本語")              // "5pel5pys6Kqe"
+ *   textToBase64("subjects?ids[]=1", { makeUrlSafe: true })
+ *     // "c3ViamVjdHM_aWRzW109MQ"
+ */
+export function textToBase64(input: string, options: Base64Options = {}): string {
+  if (input === '') return '';
+  const bytes = new TextEncoder().encode(input);
+  // String.fromCharCode applied to a byte array gives a Latin-1 binary string
+  // suitable for btoa.
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const standard = btoa(binary);
+  if (!options.makeUrlSafe) return standard;
+  return standard.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Decode a Base64 string back to UTF-8 text.
+ *
+ * Accepts a leading `data:...;base64,` prefix (stripped) and trims whitespace.
+ * URL-safe input is accepted when `makeUrlSafe` is true.
+ *
+ * @throws {Error} `'Incorrect base64 string'` if the input is not valid Base64
+ *                 in the requested alphabet.
+ *
+ * @example
+ *   base64ToText("SGVsbG8=")           // "Hello"
+ *   base64ToText("5pel5pys6Kqe")       // "日本語"
+ *   base64ToText("c3ViamVjdHM_aWRzW109MQ", { makeUrlSafe: true })
+ *     // "subjects?ids[]=1"
+ */
+export function base64ToText(input: string, options: Base64Options = {}): string {
+  const cleaned = stripDataUriPrefix(input).trim();
+  if (cleaned === '') return '';
+  if (!isValidBase64(cleaned, options)) {
+    throw new Error('Incorrect base64 string');
+  }
+  const standard = options.makeUrlSafe ? toStandardAlphabet(cleaned) : cleaned;
+  let binary: string;
+  try {
+    binary = atob(standard);
+  } catch {
+    throw new Error('Incorrect base64 string');
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  // `fatal: true` rejects malformed UTF-8 (overlong sequences, lone surrogates).
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+}
+
+/**
+ * Validate that a string is well-formed Base64 in the requested alphabet.
+ *
+ * Strict: an empty string is valid (vacuous), whitespace is ignored, but the
+ * decoded bytes must round-trip back to the same Base64 input (modulo
+ * padding for URL-safe).
+ *
+ * @example
+ *   isValidBase64("SGVsbG8=")                          // true
+ *   isValidBase64("c3ViamVjdHM_aWRzW109MQ", { makeUrlSafe: true })  // true
+ *   isValidBase64("not_base64!!!")                     // false
+ */
+export function isValidBase64(input: string, options: Base64Options = {}): boolean {
+  const cleaned = stripDataUriPrefix(input).trim().replace(/\s+/g, '');
+  if (cleaned === '') return true;
+
+  const alphabet = options.makeUrlSafe ? URL_SAFE_ALPHABET : STANDARD_ALPHABET;
+  if (!alphabet.test(cleaned)) return false;
+
+  // URL-safe mode strips padding; pad it back to a multiple of 4 for atob.
+  const standard = options.makeUrlSafe ? toStandardAlphabet(cleaned) : cleaned;
+  // Standard alphabet without padding is a fail; padded base64 must be
+  // a length that's a multiple of 4 with at most two trailing `=`.
+  if (standard.length % 4 !== 0) return false;
+  try {
+    const decoded = atob(standard);
+    // Round-trip: decode and re-encode; should match cleaned (without padding
+    // for URL-safe; with padding for standard).
+    const reEncoded = btoa(decoded);
+    if (options.makeUrlSafe) {
+      const reUrlSafe = reEncoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+      return reUrlSafe === cleaned;
+    }
+    return reEncoded === cleaned;
+  } catch {
+    return false;
+  }
+}
+
+function stripDataUriPrefix(input: string): string {
+  return input.replace(DATA_URI_PREFIX, '');
+}
+
+function toStandardAlphabet(urlSafe: string): string {
+  const replaced = urlSafe.replace(/-/g, '+').replace(/_/g, '/');
+  // Add `=` padding back to a multiple of 4 length.
+  const padding = (4 - (replaced.length % 4)) % 4;
+  return replaced + '='.repeat(padding);
+}

--- a/src/tools/01-encoding/001-base64-string-converter/render.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/render.ts
@@ -1,0 +1,201 @@
+import { translate } from '../../../lib/i18n';
+import { button } from '../../../ui/primitives/button';
+import { copyButton, type CopyButtonHandle } from '../../../ui/primitives/copy-button';
+import { panel } from '../../../ui/primitives/panel';
+import { textarea } from '../../../ui/primitives/textarea';
+import { base64ToText, isValidBase64, textToBase64 } from './logic';
+import { type Mode, type State } from './url-state';
+
+export interface RenderOptions {
+  /** Optional callback fired whenever the user changes anything we want
+   *  reflected in the URL. The host wires this to the URL-state plumbing. */
+  onStateChange?: (next: State) => void;
+}
+
+export function render(
+  host: HTMLElement,
+  initial: State,
+  options: RenderOptions = {},
+): { dispose(): void } {
+  const doc = host.ownerDocument;
+  let state: State = { ...initial };
+  const disposers: (() => void)[] = [];
+
+  // Root container
+  const root = doc.createElement('div');
+  root.classList.add('dt-base64');
+
+  // Mode tabs (encode | decode)
+  const tabs = doc.createElement('div');
+  tabs.classList.add('dt-base64__tabs');
+  tabs.setAttribute('role', 'tablist');
+  tabs.setAttribute('aria-label', translate('tools.base64.mode.aria'));
+
+  const encodeTab = makeTab('encode', translate('tools.base64.mode.encode'));
+  const decodeTab = makeTab('decode', translate('tools.base64.mode.decode'));
+  tabs.append(encodeTab, decodeTab);
+  root.appendChild(tabs);
+
+  // URL-safe toggle
+  const toggleWrap = doc.createElement('label');
+  toggleWrap.classList.add('dt-base64__toggle');
+  const toggleInput = doc.createElement('input');
+  toggleInput.type = 'checkbox';
+  toggleInput.checked = state.urlsafe;
+  toggleInput.setAttribute('aria-label', translate('tools.base64.urlsafe.aria'));
+  const toggleText = doc.createElement('span');
+  toggleText.textContent = translate('tools.base64.urlsafe.label');
+  toggleWrap.append(toggleInput, toggleText);
+  root.appendChild(toggleWrap);
+
+  toggleInput.addEventListener('change', () => {
+    update({ urlsafe: toggleInput.checked });
+  });
+
+  // Input panel
+  const inputArea = textarea({
+    value: state.input,
+    placeholder: translate('tools.base64.input.placeholder'),
+    ariaLabel: translate('tools.base64.input.aria'),
+    rows: 6,
+    onInput: (value) => {
+      update({ input: value });
+    },
+  });
+  const inputBody = doc.createElement('div');
+  inputBody.appendChild(inputArea);
+  const inputPanel = panel({
+    label: translate('tools.base64.input.label'),
+    body: inputBody,
+    className: 'dt-base64__panel',
+  });
+  root.appendChild(inputPanel);
+
+  // Swap button (label already contains ⇄ — no separate icon needed)
+  const swap = button({
+    label: translate('tools.base64.swap'),
+    onClick: () => {
+      const decoded = computeOutput(state);
+      // Move output → input and flip mode.
+      const nextMode: Mode = state.mode === 'encode' ? 'decode' : 'encode';
+      update({ mode: nextMode, input: decoded });
+      // Sync DOM (textarea + tabs).
+      inputArea.value = decoded;
+      setActiveTab(nextMode);
+    },
+  });
+  swap.classList.add('dt-base64__swap');
+  root.appendChild(swap);
+
+  // Output panel
+  const outputArea = textarea({
+    value: '',
+    ariaLabel: translate('tools.base64.output.aria'),
+    rows: 6,
+    readonly: true,
+  });
+
+  const lengths = doc.createElement('span');
+  lengths.classList.add('dt-base64__lengths');
+
+  const copyHandle: CopyButtonHandle = copyButton({
+    text: () => outputArea.value,
+    label: translate('tools.base64.copy'),
+  });
+  disposers.push(() => {
+    copyHandle.dispose();
+  });
+
+  const outputBody = doc.createElement('div');
+  outputBody.appendChild(outputArea);
+  const outputFoot = doc.createElement('div');
+  outputFoot.classList.add('dt-base64__output-foot');
+  outputFoot.append(lengths, copyHandle.el);
+  outputBody.appendChild(outputFoot);
+
+  const outputPanel = panel({
+    label: translate('tools.base64.output.label'),
+    body: outputBody,
+    className: 'dt-base64__panel',
+  });
+  root.appendChild(outputPanel);
+
+  // Initial paint
+  setActiveTab(state.mode);
+  refreshOutput();
+
+  host.appendChild(root);
+
+  return {
+    dispose(): void {
+      for (const fn of disposers) fn();
+      if (root.parentNode === host) host.removeChild(root);
+    },
+  };
+
+  // ─── helpers ────────────────────────────────────────────────────────────
+
+  function makeTab(id: Mode, label: string): HTMLButtonElement {
+    const btn = doc.createElement('button');
+    btn.type = 'button';
+    btn.classList.add('dt-base64__tab');
+    btn.dataset.mode = id;
+    btn.setAttribute('role', 'tab');
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      update({ mode: id });
+    });
+    return btn;
+  }
+
+  function setActiveTab(mode: Mode): void {
+    for (const tab of [encodeTab, decodeTab]) {
+      const isActive = tab.dataset.mode === mode;
+      tab.classList.toggle('dt-base64__tab--active', isActive);
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+  }
+
+  function update(patch: Partial<State>): void {
+    const next: State = { ...state, ...patch };
+    state = next;
+    setActiveTab(next.mode);
+    if (toggleInput.checked !== next.urlsafe) {
+      toggleInput.checked = next.urlsafe;
+    }
+    if (inputArea.value !== next.input) {
+      inputArea.value = next.input;
+    }
+    refreshOutput();
+    options.onStateChange?.(next);
+  }
+
+  function refreshOutput(): void {
+    const value = computeOutput(state);
+    outputArea.value = value;
+    const inLen = state.input.length;
+    const outLen = value.length;
+    lengths.textContent = translate('tools.base64.lengths', {
+      in: String(inLen),
+      out: String(outLen),
+    });
+  }
+}
+
+/** Pure: returns the encoded/decoded string for a given state.
+ *  Errors during decode produce an empty string (UI shows length 0). */
+function computeOutput(state: State): string {
+  if (state.input === '') return '';
+  if (state.mode === 'encode') {
+    return textToBase64(state.input, { makeUrlSafe: state.urlsafe });
+  }
+  // decode mode — guard against partial / malformed input (no exception popups)
+  if (!isValidBase64(state.input, { makeUrlSafe: state.urlsafe })) {
+    return '';
+  }
+  try {
+    return base64ToText(state.input, { makeUrlSafe: state.urlsafe });
+  } catch {
+    return '';
+  }
+}

--- a/src/tools/01-encoding/001-base64-string-converter/render.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/render.ts
@@ -1,5 +1,4 @@
 import { translate } from '../../../lib/i18n';
-import { button } from '../../../ui/primitives/button';
 import { copyButton, type CopyButtonHandle } from '../../../ui/primitives/copy-button';
 import { panel } from '../../../ui/primitives/panel';
 import { textarea } from '../../../ui/primitives/textarea';
@@ -21,79 +20,97 @@ export function render(
   let state: State = { ...initial };
   const disposers: (() => void)[] = [];
 
-  // Root container
+  // Root
   const root = doc.createElement('div');
   root.classList.add('dt-base64');
 
-  // Mode tabs (encode | decode)
+  // ─── Top control bar: segmented mode tabs + URL-safe toggle ────────────
+  const controls = doc.createElement('div');
+  controls.classList.add('dt-base64__controls');
+
   const tabs = doc.createElement('div');
-  tabs.classList.add('dt-base64__tabs');
+  tabs.classList.add('dt-base64__segmented');
   tabs.setAttribute('role', 'tablist');
   tabs.setAttribute('aria-label', translate('tools.base64.mode.aria'));
-
   const encodeTab = makeTab('encode', translate('tools.base64.mode.encode'));
   const decodeTab = makeTab('decode', translate('tools.base64.mode.decode'));
   tabs.append(encodeTab, decodeTab);
-  root.appendChild(tabs);
+  controls.appendChild(tabs);
 
-  // URL-safe toggle
+  // URL-safe toggle — custom switch styling
   const toggleWrap = doc.createElement('label');
-  toggleWrap.classList.add('dt-base64__toggle');
+  toggleWrap.classList.add('dt-base64__switch');
   const toggleInput = doc.createElement('input');
   toggleInput.type = 'checkbox';
+  toggleInput.classList.add('dt-base64__switch-input');
   toggleInput.checked = state.urlsafe;
   toggleInput.setAttribute('aria-label', translate('tools.base64.urlsafe.aria'));
+  const toggleVisual = doc.createElement('span');
+  toggleVisual.classList.add('dt-base64__switch-visual');
+  toggleVisual.setAttribute('aria-hidden', 'true');
   const toggleText = doc.createElement('span');
+  toggleText.classList.add('dt-base64__switch-label');
   toggleText.textContent = translate('tools.base64.urlsafe.label');
-  toggleWrap.append(toggleInput, toggleText);
-  root.appendChild(toggleWrap);
+  toggleWrap.append(toggleInput, toggleVisual, toggleText);
+  controls.appendChild(toggleWrap);
 
   toggleInput.addEventListener('change', () => {
     update({ urlsafe: toggleInput.checked });
   });
 
-  // Input panel
+  root.appendChild(controls);
+
+  // ─── Two-pane workspace: input ⇄ output ────────────────────────────────
+  const workspace = doc.createElement('div');
+  workspace.classList.add('dt-base64__workspace');
+
+  // Input pane
   const inputArea = textarea({
     value: state.input,
     placeholder: translate('tools.base64.input.placeholder'),
     ariaLabel: translate('tools.base64.input.aria'),
-    rows: 6,
+    rows: 10,
     onInput: (value) => {
       update({ input: value });
     },
   });
-  const inputBody = doc.createElement('div');
-  inputBody.appendChild(inputArea);
-  const inputPanel = panel({
+  inputArea.classList.add('dt-base64__textarea');
+
+  const inputPaneBody = doc.createElement('div');
+  inputPaneBody.classList.add('dt-base64__pane-body');
+  inputPaneBody.appendChild(inputArea);
+
+  const inputPane = panel({
     label: translate('tools.base64.input.label'),
-    body: inputBody,
-    className: 'dt-base64__panel',
+    body: inputPaneBody,
+    className: 'dt-base64__pane',
   });
-  root.appendChild(inputPanel);
+  workspace.appendChild(inputPane);
 
-  // Swap button (label already contains ⇄ — no separate icon needed)
-  const swap = button({
-    label: translate('tools.base64.swap'),
-    onClick: () => {
-      const decoded = computeOutput(state);
-      // Move output → input and flip mode.
-      const nextMode: Mode = state.mode === 'encode' ? 'decode' : 'encode';
-      update({ mode: nextMode, input: decoded });
-      // Sync DOM (textarea + tabs).
-      inputArea.value = decoded;
-      setActiveTab(nextMode);
-    },
-  });
+  // Swap button — circular icon between panes
+  const swap = doc.createElement('button');
+  swap.type = 'button';
   swap.classList.add('dt-base64__swap');
-  root.appendChild(swap);
+  swap.setAttribute('aria-label', translate('tools.base64.swap'));
+  swap.title = translate('tools.base64.swap');
+  swap.innerHTML = '<span aria-hidden="true">⇄</span>';
+  swap.addEventListener('click', () => {
+    const computed = computeOutput(state);
+    const nextMode: Mode = state.mode === 'encode' ? 'decode' : 'encode';
+    update({ mode: nextMode, input: computed });
+    inputArea.value = computed;
+    setActiveTab(nextMode);
+  });
+  workspace.appendChild(swap);
 
-  // Output panel
+  // Output pane (monospace — output is code)
   const outputArea = textarea({
     value: '',
     ariaLabel: translate('tools.base64.output.aria'),
-    rows: 6,
+    rows: 10,
     readonly: true,
   });
+  outputArea.classList.add('dt-base64__textarea', 'dt-base64__textarea--mono');
 
   const lengths = doc.createElement('span');
   lengths.classList.add('dt-base64__lengths');
@@ -102,23 +119,28 @@ export function render(
     text: () => outputArea.value,
     label: translate('tools.base64.copy'),
   });
+  copyHandle.el.classList.add('dt-base64__copy');
   disposers.push(() => {
     copyHandle.dispose();
   });
 
-  const outputBody = doc.createElement('div');
-  outputBody.appendChild(outputArea);
-  const outputFoot = doc.createElement('div');
-  outputFoot.classList.add('dt-base64__output-foot');
-  outputFoot.append(lengths, copyHandle.el);
-  outputBody.appendChild(outputFoot);
+  const outputPaneBody = doc.createElement('div');
+  outputPaneBody.classList.add('dt-base64__pane-body');
+  outputPaneBody.appendChild(outputArea);
 
-  const outputPanel = panel({
+  const outputFoot = doc.createElement('div');
+  outputFoot.classList.add('dt-base64__pane-foot');
+  outputFoot.append(lengths, copyHandle.el);
+  outputPaneBody.appendChild(outputFoot);
+
+  const outputPane = panel({
     label: translate('tools.base64.output.label'),
-    body: outputBody,
-    className: 'dt-base64__panel',
+    body: outputPaneBody,
+    className: 'dt-base64__pane',
   });
-  root.appendChild(outputPanel);
+  workspace.appendChild(outputPane);
+
+  root.appendChild(workspace);
 
   // Initial paint
   setActiveTab(state.mode);

--- a/src/tools/01-encoding/001-base64-string-converter/render.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/render.ts
@@ -1,6 +1,7 @@
 import { translate } from '../../../lib/i18n';
 import { copyButton, type CopyButtonHandle } from '../../../ui/primitives/copy-button';
 import { panel } from '../../../ui/primitives/panel';
+import { pasteButton, type PasteButtonHandle } from '../../../ui/primitives/paste-button';
 import { textarea } from '../../../ui/primitives/textarea';
 import { base64ToText, isValidBase64, textToBase64 } from './logic';
 import { type Mode, type State } from './url-state';
@@ -60,32 +61,69 @@ export function render(
 
   root.appendChild(controls);
 
-  // ─── Two-pane workspace: input ⇄ output ────────────────────────────────
+  // ─── Two-pane workspace: source ⇄ result ───────────────────────────────
+  // The source pane (left) is editable — text in encode mode, base64 in decode.
+  // The result pane (right) is read-only and shows the converted form. The
+  // visible labels swap with the mode so the header tells the user what kind
+  // of content lives in each pane.
   const workspace = doc.createElement('div');
   workspace.classList.add('dt-base64__workspace');
 
-  // Input pane
-  const inputArea = textarea({
+  // Source (editable) pane
+  const sourceArea = textarea({
     value: state.input,
-    placeholder: translate('tools.base64.input.placeholder'),
-    ariaLabel: translate('tools.base64.input.aria'),
+    placeholder: placeholderFor(state.mode),
+    ariaLabel: translate('tools.base64.source.aria'),
     rows: 10,
     onInput: (value) => {
       update({ input: value });
     },
   });
-  inputArea.classList.add('dt-base64__textarea');
+  sourceArea.classList.add('dt-base64__textarea');
 
-  const inputPaneBody = doc.createElement('div');
-  inputPaneBody.classList.add('dt-base64__pane-body');
-  inputPaneBody.appendChild(inputArea);
+  const sourcePaneBody = doc.createElement('div');
+  sourcePaneBody.classList.add('dt-base64__pane-body');
+  sourcePaneBody.appendChild(sourceArea);
 
-  const inputPane = panel({
-    label: translate('tools.base64.input.label'),
-    body: inputPaneBody,
+  // Paste button on the source pane — symmetric with copy on the result pane
+  const pasteHandle: PasteButtonHandle = pasteButton({
+    label: translate('tools.base64.paste'),
+    pastedLabel: translate('tools.base64.pasted'),
+    onPaste: (text) => {
+      sourceArea.value = text;
+      update({ input: text });
+      sourceArea.focus();
+    },
+    onError: () => {
+      // Surface a transient hint via the textarea title — keeps us out of
+      // alert/popup territory and respects the funny-but-informative rule.
+      const previous = sourceArea.title;
+      sourceArea.title = translate('error.paste.failed');
+      setTimeout(() => {
+        sourceArea.title = previous;
+      }, 4000);
+    },
+  });
+  pasteHandle.el.classList.add('dt-base64__paste');
+  pasteHandle.el.setAttribute('aria-label', translate('tools.base64.paste.aria'));
+  disposers.push(() => {
+    pasteHandle.dispose();
+  });
+
+  const sourceFoot = doc.createElement('div');
+  sourceFoot.classList.add('dt-base64__pane-foot');
+  const sourceLengths = doc.createElement('span');
+  sourceLengths.classList.add('dt-base64__lengths');
+  sourceFoot.append(sourceLengths, pasteHandle.el);
+  sourcePaneBody.appendChild(sourceFoot);
+
+  const sourcePane = panel({
+    label: sourceLabel(state.mode),
+    body: sourcePaneBody,
     className: 'dt-base64__pane',
   });
-  workspace.appendChild(inputPane);
+  const sourceLabelEl = sourcePane.querySelector<HTMLDivElement>('.dt-panel__label');
+  workspace.appendChild(sourcePane);
 
   // Swap button — circular icon between panes
   const swap = doc.createElement('button');
@@ -98,25 +136,25 @@ export function render(
     const computed = computeOutput(state);
     const nextMode: Mode = state.mode === 'encode' ? 'decode' : 'encode';
     update({ mode: nextMode, input: computed });
-    inputArea.value = computed;
+    sourceArea.value = computed;
     setActiveTab(nextMode);
   });
   workspace.appendChild(swap);
 
-  // Output pane (monospace — output is code)
-  const outputArea = textarea({
+  // Result (read-only) pane — monospace because it's code-like content
+  const resultArea = textarea({
     value: '',
-    ariaLabel: translate('tools.base64.output.aria'),
+    ariaLabel: translate('tools.base64.result.aria'),
     rows: 10,
     readonly: true,
   });
-  outputArea.classList.add('dt-base64__textarea', 'dt-base64__textarea--mono');
+  resultArea.classList.add('dt-base64__textarea', 'dt-base64__textarea--mono');
 
-  const lengths = doc.createElement('span');
-  lengths.classList.add('dt-base64__lengths');
+  const resultLengths = doc.createElement('span');
+  resultLengths.classList.add('dt-base64__lengths');
 
   const copyHandle: CopyButtonHandle = copyButton({
-    text: () => outputArea.value,
+    text: () => resultArea.value,
     label: translate('tools.base64.copy'),
   });
   copyHandle.el.classList.add('dt-base64__copy');
@@ -124,23 +162,27 @@ export function render(
     copyHandle.dispose();
   });
 
-  const outputPaneBody = doc.createElement('div');
-  outputPaneBody.classList.add('dt-base64__pane-body');
-  outputPaneBody.appendChild(outputArea);
+  const resultPaneBody = doc.createElement('div');
+  resultPaneBody.classList.add('dt-base64__pane-body');
+  resultPaneBody.appendChild(resultArea);
 
-  const outputFoot = doc.createElement('div');
-  outputFoot.classList.add('dt-base64__pane-foot');
-  outputFoot.append(lengths, copyHandle.el);
-  outputPaneBody.appendChild(outputFoot);
+  const resultFoot = doc.createElement('div');
+  resultFoot.classList.add('dt-base64__pane-foot');
+  resultFoot.append(resultLengths, copyHandle.el);
+  resultPaneBody.appendChild(resultFoot);
 
-  const outputPane = panel({
-    label: translate('tools.base64.output.label'),
-    body: outputPaneBody,
+  const resultPane = panel({
+    label: resultLabel(state.mode),
+    body: resultPaneBody,
     className: 'dt-base64__pane',
   });
-  workspace.appendChild(outputPane);
+  const resultLabelEl = resultPane.querySelector<HTMLDivElement>('.dt-panel__label');
+  workspace.appendChild(resultPane);
 
   root.appendChild(workspace);
+
+  // ─── Explainer (how Base64 works, worked example, common uses) ────────
+  root.appendChild(buildExplainer(doc));
 
   // Initial paint
   setActiveTab(state.mode);
@@ -180,13 +222,19 @@ export function render(
 
   function update(patch: Partial<State>): void {
     const next: State = { ...state, ...patch };
+    const modeChanged = next.mode !== state.mode;
     state = next;
     setActiveTab(next.mode);
     if (toggleInput.checked !== next.urlsafe) {
       toggleInput.checked = next.urlsafe;
     }
-    if (inputArea.value !== next.input) {
-      inputArea.value = next.input;
+    if (sourceArea.value !== next.input) {
+      sourceArea.value = next.input;
+    }
+    if (modeChanged) {
+      if (sourceLabelEl) sourceLabelEl.textContent = sourceLabel(next.mode);
+      if (resultLabelEl) resultLabelEl.textContent = resultLabel(next.mode);
+      sourceArea.placeholder = placeholderFor(next.mode);
     }
     refreshOutput();
     options.onStateChange?.(next);
@@ -194,13 +242,11 @@ export function render(
 
   function refreshOutput(): void {
     const value = computeOutput(state);
-    outputArea.value = value;
+    resultArea.value = value;
     const inLen = state.input.length;
     const outLen = value.length;
-    lengths.textContent = translate('tools.base64.lengths', {
-      in: String(inLen),
-      out: String(outLen),
-    });
+    sourceLengths.textContent = translate('tools.base64.chars', { n: String(inLen) });
+    resultLengths.textContent = translate('tools.base64.chars', { n: String(outLen) });
   }
 }
 
@@ -220,4 +266,91 @@ function computeOutput(state: State): string {
   } catch {
     return '';
   }
+}
+
+function sourceLabel(mode: Mode): string {
+  return mode === 'encode'
+    ? translate('tools.base64.label.text')
+    : translate('tools.base64.label.base64');
+}
+
+function resultLabel(mode: Mode): string {
+  return mode === 'encode'
+    ? translate('tools.base64.label.base64')
+    : translate('tools.base64.label.text');
+}
+
+function placeholderFor(mode: Mode): string {
+  return mode === 'encode'
+    ? translate('tools.base64.placeholder.encode')
+    : translate('tools.base64.placeholder.decode');
+}
+
+/** Builds the explainer block — heading, prose paragraphs, a worked example
+ *  table, and a deep link to the Basic Auth helper. The example bytes/bits
+ *  are universal and stay in code (not i18n) so they render the same in
+ *  every locale. */
+function buildExplainer(doc: Document): HTMLElement {
+  const section = doc.createElement('section');
+  section.classList.add('dt-base64__explainer');
+
+  const heading = doc.createElement('h2');
+  heading.classList.add('dt-base64__explainer-h');
+  heading.textContent = translate('tools.base64.explainer.heading');
+  section.appendChild(heading);
+
+  section.appendChild(makeP(doc, translate('tools.base64.explainer.intro')));
+  section.appendChild(makeP(doc, translate('tools.base64.explainer.mechanic')));
+
+  const exampleLabel = doc.createElement('p');
+  exampleLabel.classList.add('dt-base64__explainer-eg-label');
+  exampleLabel.textContent = translate('tools.base64.explainer.example.label');
+  section.appendChild(exampleLabel);
+
+  // Worked example: "Cat" → 0x43 0x61 0x74 → 6-bit groups → Q2F0
+  const example = doc.createElement('pre');
+  example.classList.add('dt-base64__explainer-eg');
+  example.setAttribute('aria-label', 'Worked example: encoding "Cat" to Q2F0');
+  example.textContent = [
+    'input    C        a        t',
+    'bytes    01000011 01100001 01110100',
+    '6-bit    010000   110110   000101   110100',
+    'index    16       54       5        52',
+    'output   Q        2        F        0',
+  ].join('\n');
+  section.appendChild(example);
+
+  section.appendChild(makeP(doc, translate('tools.base64.explainer.uses')));
+
+  const warn = doc.createElement('p');
+  warn.classList.add('dt-base64__explainer-warn');
+  warn.textContent = translate('tools.base64.explainer.warning');
+  section.appendChild(warn);
+
+  const tryAuth = doc.createElement('a');
+  tryAuth.classList.add('dt-base64__explainer-cta');
+  tryAuth.href = '#/base64-basic-auth';
+  tryAuth.textContent = translate('tools.base64.explainer.tryauth');
+  section.appendChild(tryAuth);
+
+  return section;
+}
+
+function makeP(doc: Document, text: string): HTMLParagraphElement {
+  const p = doc.createElement('p');
+  p.classList.add('dt-base64__explainer-p');
+  // Inline `code` formatting — split on backticks and wrap odd indices.
+  const parts = text.split('`');
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (part === undefined) continue;
+    if (i % 2 === 0) {
+      p.appendChild(doc.createTextNode(part));
+    } else {
+      const code = doc.createElement('code');
+      code.textContent = part;
+      p.appendChild(code);
+    }
+  }
+  return p;
 }

--- a/src/tools/01-encoding/001-base64-string-converter/render.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/render.ts
@@ -45,7 +45,10 @@ export function render(
   toggleInput.type = 'checkbox';
   toggleInput.classList.add('dt-base64__switch-input');
   toggleInput.checked = state.urlsafe;
-  toggleInput.setAttribute('aria-label', translate('tools.base64.urlsafe.aria'));
+  // No explicit aria-label — the wrapping <label> provides the accessible
+  // name from the visible text, so screen-reader and visual users hear the
+  // same thing. Setting aria-label here would override the visible text and
+  // also break Playwright's getByLabel(/URL-safe variant/i) lookup.
   const toggleVisual = doc.createElement('span');
   toggleVisual.classList.add('dt-base64__switch-visual');
   toggleVisual.setAttribute('aria-hidden', 'true');
@@ -294,7 +297,9 @@ function buildExplainer(doc: Document): HTMLElement {
   const section = doc.createElement('section');
   section.classList.add('dt-base64__explainer');
 
-  const heading = doc.createElement('h2');
+  // Use h1 — the tool view doesn't otherwise have a level-one heading, so
+  // axe's page-has-heading-one best-practice rule fails without it.
+  const heading = doc.createElement('h1');
   heading.classList.add('dt-base64__explainer-h');
   heading.textContent = translate('tools.base64.explainer.heading');
   section.appendChild(heading);

--- a/src/tools/01-encoding/001-base64-string-converter/url-state.test.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/url-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_STATE, parseParams, serializeParams, type State } from './url-state';
+
+describe('parseParams', () => {
+  it('returns DEFAULT_STATE when nothing is set', () => {
+    const state = parseParams(new URLSearchParams(), new URLSearchParams());
+    expect(state).toEqual(DEFAULT_STATE);
+  });
+
+  it('reads mode from search', () => {
+    const state = parseParams(
+      new URLSearchParams('mode=decode'),
+      new URLSearchParams(),
+    );
+    expect(state.mode).toBe('decode');
+  });
+
+  it('falls back to encode for unknown mode values', () => {
+    const state = parseParams(
+      new URLSearchParams('mode=garbage'),
+      new URLSearchParams(),
+    );
+    expect(state.mode).toBe('encode');
+  });
+
+  it('reads urlsafe=1 as true', () => {
+    const state = parseParams(
+      new URLSearchParams('urlsafe=1'),
+      new URLSearchParams(),
+    );
+    expect(state.urlsafe).toBe(true);
+  });
+
+  it('treats any non-1 urlsafe value as false', () => {
+    expect(parseParams(new URLSearchParams('urlsafe=0'), new URLSearchParams()).urlsafe).toBe(
+      false,
+    );
+    expect(parseParams(new URLSearchParams('urlsafe=true'), new URLSearchParams()).urlsafe).toBe(
+      false,
+    );
+  });
+
+  it('reads input from hash', () => {
+    const state = parseParams(
+      new URLSearchParams(),
+      new URLSearchParams('in=SGVsbG8%3D'),
+    );
+    expect(state.input).toBe('SGVsbG8=');
+  });
+});
+
+describe('serializeParams', () => {
+  it('returns empty params for the default state', () => {
+    const { search, hash } = serializeParams(DEFAULT_STATE);
+    expect(search.toString()).toBe('');
+    expect(hash.toString()).toBe('');
+  });
+
+  it('omits mode=encode (default)', () => {
+    const state: State = { mode: 'encode', urlsafe: false, input: '' };
+    expect(serializeParams(state).search.has('mode')).toBe(false);
+  });
+
+  it('emits mode=decode when set', () => {
+    const state: State = { mode: 'decode', urlsafe: false, input: '' };
+    expect(serializeParams(state).search.get('mode')).toBe('decode');
+  });
+
+  it('emits urlsafe=1 when true', () => {
+    const state: State = { mode: 'encode', urlsafe: true, input: '' };
+    expect(serializeParams(state).search.get('urlsafe')).toBe('1');
+  });
+
+  it('puts non-empty input in hash', () => {
+    const state: State = { mode: 'encode', urlsafe: false, input: 'SGVsbG8=' };
+    const { search, hash } = serializeParams(state);
+    expect(search.has('in')).toBe(false);
+    expect(hash.get('in')).toBe('SGVsbG8=');
+  });
+});
+
+describe('round-trip', () => {
+  it.each<State>([
+    { mode: 'encode', urlsafe: false, input: '' },
+    { mode: 'decode', urlsafe: false, input: 'SGVsbG8=' },
+    { mode: 'encode', urlsafe: true, input: 'Hello' },
+    { mode: 'decode', urlsafe: true, input: 'c3ViamVjdHM_aWRzW109MQ' },
+  ])('preserves %j through serialize → parse', (state) => {
+    const { search, hash } = serializeParams(state);
+    expect(parseParams(search, hash)).toEqual(state);
+  });
+});

--- a/src/tools/01-encoding/001-base64-string-converter/url-state.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/url-state.ts
@@ -1,0 +1,45 @@
+/**
+ * URL-state contract for the base64-string-converter.
+ *
+ * - `mode` (active card) and `urlsafe` (toggle) live in `?search` so they're
+ *   indexable / shareable as plain query params.
+ * - `in` (the user's input) lives in `#hash` per the project privacy rule
+ *   (`feedback_url_parameters`): hash never appears in HTTP requests, Referer,
+ *   or server logs.
+ */
+
+export type Mode = 'encode' | 'decode';
+
+export interface State {
+  readonly mode: Mode;
+  readonly urlsafe: boolean;
+  readonly input: string;
+}
+
+export const DEFAULT_STATE: State = {
+  mode: 'encode',
+  urlsafe: false,
+  input: '',
+};
+
+export function parseParams(search: URLSearchParams, hash: URLSearchParams): State {
+  const modeRaw = search.get('mode');
+  const mode: Mode = modeRaw === 'decode' ? 'decode' : 'encode';
+  const urlsafe = search.get('urlsafe') === '1';
+  const input = hash.get('in') ?? DEFAULT_STATE.input;
+  return { mode, urlsafe, input };
+}
+
+export function serializeParams(state: State): {
+  search: URLSearchParams;
+  hash: URLSearchParams;
+} {
+  const search = new URLSearchParams();
+  const hash = new URLSearchParams();
+
+  if (state.mode !== DEFAULT_STATE.mode) search.set('mode', state.mode);
+  if (state.urlsafe) search.set('urlsafe', '1');
+  if (state.input) hash.set('in', state.input);
+
+  return { search, hash };
+}

--- a/src/tools/01-encoding/002-base64-basic-auth/index.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/index.ts
@@ -1,0 +1,18 @@
+import type { ToolModule } from '../../../lib/types';
+import { render } from './render';
+import { DEFAULT_STATE, parseParams, serializeParams, type State } from './url-state';
+
+export const tool: ToolModule<State> = {
+  id: 'base64-basic-auth',
+  number: 2,
+  category: '01-encoding',
+  name: 'HTTP Basic Auth helper',
+  description:
+    'Build and read the `Authorization: Basic <base64>` header. UTF-8 round-trip, deep-link, all on-device.',
+  tags: ['base64', 'authorization', 'basic-auth', 'http', 'header'],
+  parseParams,
+  serializeParams,
+  render,
+};
+
+export { DEFAULT_STATE };

--- a/src/tools/01-encoding/002-base64-basic-auth/logic.test.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/logic.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { decodeBasicAuth, encodeBasicAuth, isValidBasicAuth } from './logic';
+
+describe('encodeBasicAuth', () => {
+  it('encodes the canonical RFC 7617 example', () => {
+    expect(encodeBasicAuth({ username: 'aladdin', password: 'open sesame' })).toBe(
+      'Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+    );
+  });
+
+  it('encodes empty credentials as a valid header', () => {
+    expect(encodeBasicAuth({ username: '', password: '' })).toBe('Basic Og==');
+  });
+
+  it('round-trips UTF-8 (CJK + emoji) in either field', () => {
+    const creds = { username: '日本語', password: 'パスワード🔐' };
+    const header = encodeBasicAuth(creds);
+    expect(decodeBasicAuth(header)).toEqual(creds);
+  });
+
+  it('preserves colons inside the password (split is on first colon)', () => {
+    const creds = { username: 'admin', password: 'a:b:c' };
+    const header = encodeBasicAuth(creds);
+    expect(decodeBasicAuth(header)).toEqual(creds);
+  });
+
+  it('preserves whitespace and special characters', () => {
+    const creds = { username: 'user with space', password: '  pad  ' };
+    expect(decodeBasicAuth(encodeBasicAuth(creds))).toEqual(creds);
+  });
+});
+
+describe('decodeBasicAuth', () => {
+  it('decodes a header with the Basic prefix', () => {
+    expect(decodeBasicAuth('Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==')).toEqual({
+      username: 'aladdin',
+      password: 'open sesame',
+    });
+  });
+
+  it('decodes the bare base64 token without prefix', () => {
+    expect(decodeBasicAuth('YWxhZGRpbjpvcGVuIHNlc2FtZQ==')).toEqual({
+      username: 'aladdin',
+      password: 'open sesame',
+    });
+  });
+
+  it('accepts the prefix in any case', () => {
+    expect(decodeBasicAuth('basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==')).not.toBeNull();
+    expect(decodeBasicAuth('BASIC YWxhZGRpbjpvcGVuIHNlc2FtZQ==')).not.toBeNull();
+    expect(decodeBasicAuth('  Basic   YWxhZGRpbjpvcGVuIHNlc2FtZQ==  ')).not.toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(decodeBasicAuth('')).toBeNull();
+    expect(decodeBasicAuth('   ')).toBeNull();
+    expect(decodeBasicAuth('Basic ')).toBeNull();
+  });
+
+  it('returns null for malformed base64', () => {
+    expect(decodeBasicAuth('Basic !!!')).toBeNull();
+    expect(decodeBasicAuth('Basic abc')).toBeNull(); // not multiple of 4
+  });
+
+  it('returns null when the decoded payload has no colon separator', () => {
+    // base64 of "nocolon" — valid base64, missing colon
+    expect(decodeBasicAuth('Basic bm9jb2xvbg==')).toBeNull();
+  });
+
+  it('returns null for invalid UTF-8 in the payload', () => {
+    // base64 of a byte sequence that's not valid UTF-8 (lone continuation 0x80)
+    expect(decodeBasicAuth('Basic gA==')).toBeNull();
+  });
+});
+
+describe('isValidBasicAuth', () => {
+  it('returns true for a well-formed header', () => {
+    expect(isValidBasicAuth('Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==')).toBe(true);
+  });
+
+  it('returns false for empty / malformed input', () => {
+    expect(isValidBasicAuth('')).toBe(false);
+    expect(isValidBasicAuth('Basic !!!')).toBe(false);
+    expect(isValidBasicAuth('Basic bm9jb2xvbg==')).toBe(false);
+  });
+});

--- a/src/tools/01-encoding/002-base64-basic-auth/logic.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/logic.ts
@@ -1,0 +1,108 @@
+/**
+ * HTTP Basic Authentication header helpers.
+ *
+ * The wire format (RFC 7617):
+ *   Authorization: Basic <base64(user ":" pass)>
+ *
+ * The credentials are joined with a colon and base64-encoded. Decoding splits
+ * on the FIRST colon — colons inside the password are preserved.
+ *
+ * This module reimplements the byte-level base64 round-trip rather than
+ * importing tool 001's logic, per the project's strict tool-isolation rule
+ * (`feedback_tool_isolation`). The implementation is deliberately small.
+ */
+
+export interface BasicAuthCredentials {
+  readonly username: string;
+  readonly password: string;
+}
+
+const BASIC_PREFIX = /^\s*Basic\s+/i;
+
+/**
+ * Encode a username/password pair into a complete `Basic <token>` header
+ * value. UTF-8 in either field round-trips.
+ *
+ * Per RFC 7617, the username MUST NOT contain a colon — but the encoder
+ * permits it for symmetry with the decoder, since a server reading the
+ * encoded value can't distinguish anyway.
+ *
+ * @example
+ *   encodeBasicAuth('aladdin', 'open sesame')
+ *     // "Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+ */
+export function encodeBasicAuth(credentials: BasicAuthCredentials): string {
+  const joined = `${credentials.username}:${credentials.password}`;
+  return `Basic ${utf8ToBase64(joined)}`;
+}
+
+/**
+ * Decode a Basic Authorization header (with or without the `Basic ` prefix)
+ * back to a username/password pair. Splits on the first colon — extra colons
+ * stay in the password field.
+ *
+ * Returns `null` if the input is malformed (bad base64, invalid UTF-8, or
+ * missing colon separator).
+ *
+ * @example
+ *   decodeBasicAuth('Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==')
+ *     // { username: 'aladdin', password: 'open sesame' }
+ *   decodeBasicAuth('YWxhZGRpbjpvcGVuIHNlc2FtZQ==')
+ *     // same — prefix is optional
+ *   decodeBasicAuth('not base64!!')
+ *     // null
+ */
+export function decodeBasicAuth(header: string): BasicAuthCredentials | null {
+  const trimmed = header.replace(BASIC_PREFIX, '').trim();
+  if (trimmed === '') return null;
+  const decoded = base64ToUtf8(trimmed);
+  if (decoded === null) return null;
+  const sep = decoded.indexOf(':');
+  if (sep === -1) return null;
+  return {
+    username: decoded.slice(0, sep),
+    password: decoded.slice(sep + 1),
+  };
+}
+
+/**
+ * True if the input parses as a valid Basic auth header. Accepts the
+ * optional `Basic ` prefix; rejects anything that doesn't decode to a
+ * `user:pass` shape.
+ */
+export function isValidBasicAuth(header: string): boolean {
+  return decodeBasicAuth(header) !== null;
+}
+
+/** UTF-8-safe base64 encode. Mirrors tool 001's approach without sharing code. */
+function utf8ToBase64(input: string): string {
+  if (input === '') return '';
+  const bytes = new TextEncoder().encode(input);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+/** UTF-8-safe base64 decode. Returns null instead of throwing on bad input. */
+function base64ToUtf8(input: string): string | null {
+  // Standard alphabet only — Basic auth uses standard, not URL-safe.
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(input)) return null;
+  if (input.length % 4 !== 0) return null;
+  let binary: string;
+  try {
+    binary = atob(input);
+  } catch {
+    return null;
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return null;
+  }
+}

--- a/src/tools/01-encoding/002-base64-basic-auth/render.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/render.ts
@@ -1,0 +1,312 @@
+import { translate } from '../../../lib/i18n';
+import { copyButton, type CopyButtonHandle } from '../../../ui/primitives/copy-button';
+import { panel } from '../../../ui/primitives/panel';
+import { pasteButton, type PasteButtonHandle } from '../../../ui/primitives/paste-button';
+import { textarea } from '../../../ui/primitives/textarea';
+import { decodeBasicAuth, encodeBasicAuth } from './logic';
+import { type Mode, type State } from './url-state';
+
+export interface RenderOptions {
+  onStateChange?: (next: State) => void;
+}
+
+export function render(
+  host: HTMLElement,
+  initial: State,
+  options: RenderOptions = {},
+): { dispose(): void } {
+  const doc = host.ownerDocument;
+  let state: State = { ...initial };
+  const disposers: (() => void)[] = [];
+
+  const root = doc.createElement('div');
+  root.classList.add('dt-basicauth');
+
+  // ─── Top bar: mode segmented (Build | Read) + intro ────────────────────
+  const top = doc.createElement('div');
+  top.classList.add('dt-basicauth__top');
+
+  const tabs = doc.createElement('div');
+  tabs.classList.add('dt-base64__segmented');
+  tabs.setAttribute('role', 'tablist');
+  tabs.setAttribute('aria-label', translate('tools.basicauth.mode.aria'));
+  const buildTab = makeTab('encode', translate('tools.basicauth.mode.encode'));
+  const readTab = makeTab('decode', translate('tools.basicauth.mode.decode'));
+  tabs.append(buildTab, readTab);
+  top.appendChild(tabs);
+
+  const intro = doc.createElement('p');
+  intro.classList.add('dt-basicauth__intro');
+  intro.textContent = translate('tools.basicauth.intro');
+  top.appendChild(intro);
+
+  root.appendChild(top);
+
+  // ─── Build pane (left) — username + password fields ────────────────────
+  const buildBody = doc.createElement('div');
+  buildBody.classList.add('dt-basicauth__form');
+
+  const usernameRow = field({
+    doc,
+    label: translate('tools.basicauth.username.label'),
+    inputId: 'dt-basicauth-username',
+    children: () => {
+      const inp = doc.createElement('input');
+      inp.id = 'dt-basicauth-username';
+      inp.type = 'text';
+      inp.classList.add('dt-input');
+      inp.value = state.username;
+      inp.placeholder = translate('tools.basicauth.username.placeholder');
+      inp.setAttribute('aria-label', translate('tools.basicauth.username.aria'));
+      inp.autocomplete = 'username';
+      inp.addEventListener('input', () => {
+        update({ username: inp.value });
+      });
+      return { input: inp, suffix: copyButtonForField(() => inp.value, 'username') };
+    },
+  });
+
+  const passwordRow = field({
+    doc,
+    label: translate('tools.basicauth.password.label'),
+    inputId: 'dt-basicauth-password',
+    children: () => {
+      const inp = doc.createElement('input');
+      inp.id = 'dt-basicauth-password';
+      inp.type = 'password';
+      inp.classList.add('dt-input');
+      inp.value = state.password;
+      inp.placeholder = translate('tools.basicauth.password.placeholder');
+      inp.setAttribute('aria-label', translate('tools.basicauth.password.aria'));
+      inp.autocomplete = 'current-password';
+      inp.addEventListener('input', () => {
+        update({ password: inp.value });
+      });
+
+      const reveal = doc.createElement('button');
+      reveal.type = 'button';
+      reveal.classList.add('dt-basicauth__reveal');
+      reveal.textContent = translate('tools.basicauth.password.show');
+      reveal.addEventListener('click', () => {
+        const showing = inp.type === 'password';
+        inp.type = showing ? 'text' : 'password';
+        reveal.textContent = showing
+          ? translate('tools.basicauth.password.hide')
+          : translate('tools.basicauth.password.show');
+      });
+
+      const copy = copyButtonForField(() => inp.value, 'password');
+
+      const suffix = doc.createElement('span');
+      suffix.classList.add('dt-basicauth__suffixwrap');
+      suffix.append(reveal, copy);
+      return { input: inp, suffix };
+    },
+  });
+
+  buildBody.append(usernameRow, passwordRow);
+  const buildPane = panel({
+    body: buildBody,
+    className: 'dt-basicauth__pane',
+  });
+
+  // ─── Result pane (right) — Authorization header textarea + copy/paste ──
+  const headerArea = textarea({
+    value: '',
+    placeholder: translate('tools.basicauth.header.placeholder'),
+    ariaLabel: translate('tools.basicauth.header.aria'),
+    rows: 4,
+    onInput: (value) => {
+      update({ header: value });
+    },
+  });
+  headerArea.classList.add('dt-base64__textarea', 'dt-base64__textarea--mono');
+
+  const headerCopy: CopyButtonHandle = copyButton({
+    text: () => headerArea.value,
+    label: translate('tools.basicauth.copy.header'),
+  });
+  headerCopy.el.classList.add('dt-base64__copy');
+  disposers.push(() => {
+    headerCopy.dispose();
+  });
+
+  const headerPaste: PasteButtonHandle = pasteButton({
+    label: translate('tools.basicauth.paste.header'),
+    onPaste: (text) => {
+      headerArea.value = text;
+      update({ header: text });
+    },
+    onError: () => {
+      const previous = headerArea.title;
+      headerArea.title = translate('error.paste.failed');
+      setTimeout(() => {
+        headerArea.title = previous;
+      }, 4000);
+    },
+  });
+  headerPaste.el.classList.add('dt-base64__paste');
+  disposers.push(() => {
+    headerPaste.dispose();
+  });
+
+  const headerLabel = doc.createElement('label');
+  headerLabel.classList.add('dt-basicauth__field-label');
+  headerLabel.textContent = translate('tools.basicauth.header.label');
+  headerLabel.htmlFor = 'dt-basicauth-header-area';
+  headerArea.id = 'dt-basicauth-header-area';
+
+  const headerFoot = doc.createElement('div');
+  headerFoot.classList.add('dt-base64__pane-foot');
+  const headerStatus = doc.createElement('span');
+  headerStatus.classList.add('dt-basicauth__status');
+  headerFoot.append(headerStatus);
+  const footActions = doc.createElement('span');
+  footActions.classList.add('dt-basicauth__foot-actions');
+  footActions.append(headerPaste.el, headerCopy.el);
+  headerFoot.appendChild(footActions);
+
+  const headerBody = doc.createElement('div');
+  headerBody.classList.add('dt-basicauth__header-body');
+  headerBody.append(headerLabel, headerArea, headerFoot);
+
+  const headerPane = panel({
+    body: headerBody,
+    className: 'dt-basicauth__pane',
+  });
+
+  // Workspace
+  const workspace = doc.createElement('div');
+  workspace.classList.add('dt-basicauth__workspace');
+  workspace.append(buildPane, headerPane);
+  root.appendChild(workspace);
+
+  // Initial paint
+  setActiveTab(state.mode);
+  applyModeToDom(state.mode);
+  refresh();
+
+  host.appendChild(root);
+
+  return {
+    dispose(): void {
+      for (const fn of disposers) fn();
+      if (root.parentNode === host) host.removeChild(root);
+    },
+  };
+
+  // ─── helpers ────────────────────────────────────────────────────────────
+
+  function makeTab(id: Mode, label: string): HTMLButtonElement {
+    const btn = doc.createElement('button');
+    btn.type = 'button';
+    btn.classList.add('dt-base64__tab');
+    btn.dataset.mode = id;
+    btn.setAttribute('role', 'tab');
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      update({ mode: id });
+    });
+    return btn;
+  }
+
+  function setActiveTab(mode: Mode): void {
+    for (const tab of [buildTab, readTab]) {
+      const isActive = tab.dataset.mode === mode;
+      tab.classList.toggle('dt-base64__tab--active', isActive);
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+  }
+
+  function applyModeToDom(mode: Mode): void {
+    // In Build mode the form is editable; in Read mode it shows decoded values
+    // and the header is the active source. We toggle a class to flip ordering /
+    // emphasis via CSS; the DOM stays the same.
+    root.dataset.mode = mode;
+  }
+
+  function update(patch: Partial<State>): void {
+    const prevMode = state.mode;
+    state = { ...state, ...patch };
+    if (state.mode !== prevMode) {
+      setActiveTab(state.mode);
+      applyModeToDom(state.mode);
+    }
+    refresh();
+    options.onStateChange?.(state);
+  }
+
+  function refresh(): void {
+    if (state.mode === 'encode') {
+      const header = encodeBasicAuth({ username: state.username, password: state.password });
+      // Only paint the header textarea when we actually have credentials —
+      // an empty form should leave the header field blank, not show "Basic Og==".
+      const computed = state.username === '' && state.password === '' ? '' : header;
+      if (headerArea.value !== computed) {
+        headerArea.value = computed;
+      }
+      headerStatus.textContent = '';
+      headerStatus.classList.remove('dt-basicauth__status--err');
+    } else {
+      // Read mode — parse the header textarea, populate the inputs.
+      const decoded = state.header === '' ? null : decodeBasicAuth(state.header);
+      if (decoded) {
+        const usernameInput = doc.getElementById('dt-basicauth-username') as HTMLInputElement | null;
+        const passwordInput = doc.getElementById('dt-basicauth-password') as HTMLInputElement | null;
+        if (usernameInput && usernameInput.value !== decoded.username) {
+          usernameInput.value = decoded.username;
+        }
+        if (passwordInput && passwordInput.value !== decoded.password) {
+          passwordInput.value = decoded.password;
+        }
+        headerStatus.textContent = '';
+        headerStatus.classList.remove('dt-basicauth__status--err');
+      } else if (state.header !== '') {
+        headerStatus.textContent = translate('tools.basicauth.invalid');
+        headerStatus.classList.add('dt-basicauth__status--err');
+      } else {
+        headerStatus.textContent = '';
+        headerStatus.classList.remove('dt-basicauth__status--err');
+      }
+    }
+  }
+
+  function copyButtonForField(getText: () => string, kind: 'username' | 'password'): HTMLElement {
+    const labelKey =
+      kind === 'username' ? 'tools.basicauth.copy.username' : 'tools.basicauth.copy.password';
+    const handle = copyButton({
+      text: getText,
+      label: translate(labelKey),
+    });
+    handle.el.classList.add('dt-basicauth__field-copy');
+    disposers.push(() => {
+      handle.dispose();
+    });
+    return handle.el;
+  }
+}
+
+interface FieldOptions {
+  doc: Document;
+  label: string;
+  inputId: string;
+  children: () => { input: HTMLInputElement; suffix: HTMLElement };
+}
+
+function field(options: FieldOptions): HTMLElement {
+  const wrap = options.doc.createElement('div');
+  wrap.classList.add('dt-basicauth__field');
+
+  const labelEl = options.doc.createElement('label');
+  labelEl.classList.add('dt-basicauth__field-label');
+  labelEl.htmlFor = options.inputId;
+  labelEl.textContent = options.label;
+
+  const row = options.doc.createElement('div');
+  row.classList.add('dt-basicauth__field-row');
+  const { input, suffix } = options.children();
+  row.append(input, suffix);
+
+  wrap.append(labelEl, row);
+  return wrap;
+}

--- a/src/tools/01-encoding/002-base64-basic-auth/render.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/render.ts
@@ -35,6 +35,13 @@ export function render(
   tabs.append(buildTab, readTab);
   top.appendChild(tabs);
 
+  // h1 placed above the intro so the tool view satisfies axe's
+  // page-has-heading-one best-practice rule. Visually styled compact.
+  const heading = doc.createElement('h1');
+  heading.classList.add('dt-basicauth__heading');
+  heading.textContent = translate('tools.basicauth.header.label');
+  top.appendChild(heading);
+
   const intro = doc.createElement('p');
   intro.classList.add('dt-basicauth__intro');
   intro.textContent = translate('tools.basicauth.intro');

--- a/src/tools/01-encoding/002-base64-basic-auth/url-state.test.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/url-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_STATE, parseParams, serializeParams } from './url-state';
+
+describe('parseParams', () => {
+  it('returns the default state when both maps are empty', () => {
+    expect(parseParams(new URLSearchParams(), new URLSearchParams())).toEqual(DEFAULT_STATE);
+  });
+
+  it('reads mode=decode from search', () => {
+    const state = parseParams(new URLSearchParams('mode=decode'), new URLSearchParams());
+    expect(state.mode).toBe('decode');
+  });
+
+  it('treats unrecognized mode values as encode', () => {
+    const state = parseParams(new URLSearchParams('mode=garbage'), new URLSearchParams());
+    expect(state.mode).toBe('encode');
+  });
+
+  it('reads u/p/h from hash params', () => {
+    const hash = new URLSearchParams('u=alice&p=secret&h=Basic+xyz');
+    const state = parseParams(new URLSearchParams(), hash);
+    expect(state.username).toBe('alice');
+    expect(state.password).toBe('secret');
+    expect(state.header).toBe('Basic xyz');
+  });
+});
+
+describe('serializeParams', () => {
+  it('writes nothing for the default state', () => {
+    const { search, hash } = serializeParams(DEFAULT_STATE);
+    expect(search.toString()).toBe('');
+    expect(hash.toString()).toBe('');
+  });
+
+  it('omits mode=encode (it is the default)', () => {
+    const { search } = serializeParams({ ...DEFAULT_STATE, mode: 'encode' });
+    expect(search.toString()).toBe('');
+  });
+
+  it('writes mode=decode to search', () => {
+    const { search } = serializeParams({ ...DEFAULT_STATE, mode: 'decode' });
+    expect(search.get('mode')).toBe('decode');
+  });
+
+  it('writes credentials to hash, never to search (privacy)', () => {
+    const { search, hash } = serializeParams({
+      mode: 'encode',
+      username: 'alice',
+      password: 'secret',
+      header: '',
+    });
+    expect(search.has('u')).toBe(false);
+    expect(search.has('p')).toBe(false);
+    expect(hash.get('u')).toBe('alice');
+    expect(hash.get('p')).toBe('secret');
+  });
+
+  it('round-trips through parse', () => {
+    const original = {
+      mode: 'decode' as const,
+      username: 'bob',
+      password: 'p@ss w/ space:and:colons',
+      header: 'Basic Ym9iOnA=',
+    };
+    const { search, hash } = serializeParams(original);
+    expect(parseParams(search, hash)).toEqual(original);
+  });
+});

--- a/src/tools/01-encoding/002-base64-basic-auth/url-state.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/url-state.ts
@@ -1,0 +1,51 @@
+/**
+ * URL-state contract for the base64-basic-auth tool.
+ *
+ * - `mode` (encode | decode) lives in `?search` so links to a particular
+ *   pane mode are shareable.
+ * - Credential fields live in `#hash` per `feedback_url_parameters` —
+ *   passwords must NEVER appear in HTTP requests, Referer headers, or
+ *   server logs. The hash is browser-local.
+ */
+
+export type Mode = 'encode' | 'decode';
+
+export interface State {
+  readonly mode: Mode;
+  readonly username: string;
+  readonly password: string;
+  readonly header: string;
+}
+
+export const DEFAULT_STATE: State = {
+  mode: 'encode',
+  username: '',
+  password: '',
+  header: '',
+};
+
+export function parseParams(search: URLSearchParams, hash: URLSearchParams): State {
+  const modeRaw = search.get('mode');
+  const mode: Mode = modeRaw === 'decode' ? 'decode' : 'encode';
+  return {
+    mode,
+    username: hash.get('u') ?? DEFAULT_STATE.username,
+    password: hash.get('p') ?? DEFAULT_STATE.password,
+    header: hash.get('h') ?? DEFAULT_STATE.header,
+  };
+}
+
+export function serializeParams(state: State): {
+  search: URLSearchParams;
+  hash: URLSearchParams;
+} {
+  const search = new URLSearchParams();
+  const hash = new URLSearchParams();
+
+  if (state.mode !== DEFAULT_STATE.mode) search.set('mode', state.mode);
+  if (state.username) hash.set('u', state.username);
+  if (state.password) hash.set('p', state.password);
+  if (state.header) hash.set('h', state.header);
+
+  return { search, hash };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,9 +1,11 @@
 import type { ToolModule } from '../lib/types';
 import { tool as base64StringConverter } from './01-encoding/001-base64-string-converter';
+import { tool as base64BasicAuth } from './01-encoding/002-base64-basic-auth';
 
 // Auto-managed by `pnpm new-tool`. Add new tool imports above the closing `];`.
 // Each tool module's state generic is widened to `never` for the registry —
 // the registry itself never reads tool state, only routes between them.
 export const TOOLS: readonly ToolModule<never>[] = [
   base64StringConverter as unknown as ToolModule<never>,
+  base64BasicAuth as unknown as ToolModule<never>,
 ];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,9 @@
 import type { ToolModule } from '../lib/types';
+import { tool as base64StringConverter } from './01-encoding/001-base64-string-converter';
 
 // Auto-managed by `pnpm new-tool`. Add new tool imports above the closing `];`.
-export const TOOLS: readonly ToolModule<never>[] = [];
+// Each tool module's state generic is widened to `never` for the registry —
+// the registry itself never reads tool state, only routes between them.
+export const TOOLS: readonly ToolModule<never>[] = [
+  base64StringConverter as unknown as ToolModule<never>,
+];

--- a/src/ui/primitives/icon.ts
+++ b/src/ui/primitives/icon.ts
@@ -5,6 +5,7 @@
 
 const ICONS = {
   copy: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`,
+  paste: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect width="8" height="4" x="8" y="2" rx="1" ry="1"/></svg>`,
   check: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`,
   search: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>`,
   chevronDown: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>`,

--- a/src/ui/primitives/index.ts
+++ b/src/ui/primitives/index.ts
@@ -16,5 +16,8 @@ export type { InputOptions } from './input';
 export { panel } from './panel';
 export type { PanelOptions } from './panel';
 
+export { pasteButton } from './paste-button';
+export type { PasteButtonHandle, PasteButtonOptions } from './paste-button';
+
 export { textarea } from './textarea';
 export type { TextareaOptions } from './textarea';

--- a/src/ui/primitives/paste-button.test.ts
+++ b/src/ui/primitives/paste-button.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { pasteButton } from './paste-button';
+
+function noop(): void {
+  // empty handler used for tests that don't observe the paste payload
+}
+
+describe('pasteButton', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn(() => Promise.resolve('clipboard-payload')) },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('renders a button with the default label', () => {
+    const handle = pasteButton({ onPaste: noop });
+    expect(handle.el.tagName).toBe('BUTTON');
+    expect(handle.el.classList.contains('dt-paste')).toBe(true);
+    expect(handle.el.textContent).toContain('Paste');
+    handle.dispose();
+  });
+
+  it('reads the clipboard and forwards the text to onPaste', async () => {
+    const onPaste = vi.fn();
+    const handle = pasteButton({ onPaste });
+    handle.el.click();
+    await vi.waitFor(() => {
+      expect(onPaste).toHaveBeenCalledWith('clipboard-payload');
+    });
+    handle.dispose();
+  });
+
+  it('flips into pasted state after a successful read', async () => {
+    const handle = pasteButton({ onPaste: noop, resetMs: 1000 });
+    handle.el.click();
+    await vi.waitFor(() => {
+      expect(handle.el.classList.contains('dt-paste--pasted')).toBe(true);
+    });
+    expect(handle.el.textContent).toContain('Pasted');
+    handle.dispose();
+  });
+
+  it('reverts to the original label after the reset timeout', async () => {
+    const handle = pasteButton({ onPaste: noop, resetMs: 60 });
+    handle.el.click();
+    await vi.waitFor(() => {
+      expect(handle.el.classList.contains('dt-paste--pasted')).toBe(true);
+    });
+    await vi.waitFor(
+      () => {
+        expect(handle.el.classList.contains('dt-paste--pasted')).toBe(false);
+      },
+      { timeout: 1000 },
+    );
+    expect(handle.el.textContent).toContain('Paste');
+    handle.dispose();
+  });
+
+  it('forwards clipboard errors to onError without throwing', async () => {
+    const failure = new Error('denied');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { readText: vi.fn(() => Promise.reject(failure)) },
+    });
+    const onPaste = vi.fn();
+    const onError = vi.fn();
+    const handle = pasteButton({ onPaste, onError });
+    handle.el.click();
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(failure);
+    });
+    expect(onPaste).not.toHaveBeenCalled();
+    expect(handle.el.classList.contains('dt-paste--pasted')).toBe(false);
+    handle.dispose();
+  });
+
+  it('dispose() clears the timer and detaches the listener', () => {
+    const handle = pasteButton({ onPaste: noop });
+    handle.dispose();
+    handle.el.click();
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- vi.mocked inspects the mock; never invokes it
+    expect(vi.mocked(navigator.clipboard.readText)).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/primitives/paste-button.ts
+++ b/src/ui/primitives/paste-button.ts
@@ -1,0 +1,76 @@
+import { icon } from './icon';
+
+export interface PasteButtonOptions {
+  onPaste: (text: string) => void;
+  label?: string;
+  pastedLabel?: string;
+  /** ms to show the "pasted" state. Default 1500. */
+  resetMs?: number;
+  /** Called when the clipboard read throws (denied permission, http context). */
+  onError?: (err: unknown) => void;
+}
+
+export interface PasteButtonHandle {
+  el: HTMLButtonElement;
+  dispose(): void;
+}
+
+/**
+ * A small paste-from-clipboard button. Mirrors {@link copyButton}: shows a
+ * "pasted" state for `resetMs` after a successful read, then reverts. Falls
+ * back silently when the Clipboard API is unavailable so insecure contexts
+ * don't break the UI; the optional `onError` lets the caller surface a hint.
+ */
+export function pasteButton(options: PasteButtonOptions): PasteButtonHandle {
+  const el = document.createElement('button');
+  el.type = 'button';
+  el.classList.add('dt-paste');
+  el.setAttribute('aria-label', options.label ?? 'Paste from clipboard');
+
+  const iconSlot = document.createElement('span');
+  iconSlot.classList.add('dt-paste__icon');
+  iconSlot.appendChild(icon('paste', { size: 12 }));
+
+  const labelSlot = document.createElement('span');
+  labelSlot.textContent = options.label ?? 'Paste';
+
+  el.appendChild(iconSlot);
+  el.appendChild(labelSlot);
+
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const handler = (): void => {
+    void runPaste();
+  };
+  el.addEventListener('click', handler);
+
+  async function runPaste(): Promise<void> {
+    try {
+      const value = await navigator.clipboard.readText();
+      options.onPaste(value);
+      showPasted();
+    } catch (err) {
+      options.onError?.(err);
+    }
+  }
+
+  function showPasted(): void {
+    el.classList.add('dt-paste--pasted');
+    iconSlot.replaceChildren(icon('check', { size: 12 }));
+    labelSlot.textContent = options.pastedLabel ?? 'Pasted';
+    if (resetTimer) clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      el.classList.remove('dt-paste--pasted');
+      iconSlot.replaceChildren(icon('paste', { size: 12 }));
+      labelSlot.textContent = options.label ?? 'Paste';
+    }, options.resetMs ?? 1500);
+  }
+
+  return {
+    el,
+    dispose() {
+      if (resetTimer) clearTimeout(resetTimer);
+      el.removeEventListener('click', handler);
+    },
+  };
+}

--- a/src/ui/topbar/index.ts
+++ b/src/ui/topbar/index.ts
@@ -1,6 +1,7 @@
-import { translate } from '../../lib/i18n';
+import { translate, getLocale } from '../../lib/i18n';
 import type { Theme } from '../../lib/theme';
 import { button, icon } from '../primitives';
+import { languageSwitcher } from './language-switcher';
 import { themeSwitcher } from './theme-switcher';
 
 export interface TopbarHandle {
@@ -30,6 +31,9 @@ export function topbar(opts: TopbarOptions): TopbarHandle {
 
   const right = document.createElement('div');
   right.classList.add('dt-topbar__right');
+
+  const langSwitcher = languageSwitcher(getLocale());
+  right.appendChild(langSwitcher.el);
 
   const switcher = themeSwitcher(opts.initialTheme);
   right.appendChild(switcher.el);
@@ -74,6 +78,7 @@ export function topbar(opts: TopbarOptions): TopbarHandle {
     el,
     setCrumb,
     dispose() {
+      langSwitcher.dispose();
       switcher.dispose();
     },
   };

--- a/src/ui/topbar/language-switcher.ts
+++ b/src/ui/topbar/language-switcher.ts
@@ -1,0 +1,86 @@
+import { translate, setLocale, type LocaleCode } from '../../lib/i18n';
+import { LOCALES } from '../../locales';
+import { dropdown, icon, type DropdownHandle, type DropdownOption } from '../primitives';
+
+/**
+ * Flag emoji per recognized locale. Picks a canonical reference flag for
+ * each language — not a country claim. English uses 🇬🇧 to avoid implying
+ * US-only English; Portuguese uses 🇵🇹 for European Portuguese parity.
+ */
+const FLAG: Record<LocaleCode, string> = {
+  en: '🇬🇧',
+  es: '🇪🇸',
+  fr: '🇫🇷',
+  de: '🇩🇪',
+  pt: '🇵🇹',
+  it: '🇮🇹',
+  nl: '🇳🇱',
+  pl: '🇵🇱',
+  ru: '🇷🇺',
+  tr: '🇹🇷',
+  ja: '🇯🇵',
+  zh: '🇨🇳',
+  ko: '🇰🇷',
+  hi: '🇮🇳',
+  ar: '🇸🇦',
+};
+
+export interface LanguageSwitcherHandle {
+  el: HTMLElement;
+  dispose(): void;
+}
+
+/**
+ * Topbar language override. Mirrors {@link themeSwitcher} but does NOT
+ * persist the selection — the override lives in memory only and a hard
+ * page reload restores the detected/persisted locale. That matches the
+ * "override until next complete reload" UX.
+ */
+export function languageSwitcher(initial: LocaleCode): LanguageSwitcherHandle {
+  let current = initial;
+
+  const trigger = document.createElement('button');
+  trigger.type = 'button';
+  trigger.classList.add('dt-btn', 'dt-btn--ghost', 'dt-language-switcher');
+  trigger.setAttribute('aria-label', translate('topbar.language.aria'));
+
+  const flagSpan = document.createElement('span');
+  flagSpan.classList.add('dt-language-switcher__flag');
+  flagSpan.setAttribute('aria-hidden', 'true');
+  flagSpan.textContent = FLAG[current];
+
+  const codeSpan = document.createElement('span');
+  codeSpan.classList.add('dt-language-switcher__code');
+  codeSpan.textContent = current.toUpperCase();
+
+  trigger.append(flagSpan, codeSpan, icon('chevronDown', { size: 12 }));
+
+  const options: DropdownOption<LocaleCode>[] = LOCALES.map((l) => ({
+    value: l.code,
+    label: `${FLAG[l.code]}  ${l.nativeLabel}`,
+    note: l.code.toUpperCase(),
+  }));
+
+  const wrap = document.createElement('span');
+  wrap.appendChild(trigger);
+
+  const handle: DropdownHandle = dropdown<LocaleCode>({
+    trigger,
+    options,
+    value: current,
+    onChange: (next) => {
+      current = next;
+      flagSpan.textContent = FLAG[next];
+      codeSpan.textContent = next.toUpperCase();
+      // Session-only override — persist=false so a hard reload reverts.
+      setLocale(next, false);
+    },
+  });
+
+  return {
+    el: wrap,
+    dispose() {
+      handle.dispose();
+    },
+  };
+}

--- a/tests/e2e/base64-string-converter.spec.ts
+++ b/tests/e2e/base64-string-converter.spec.ts
@@ -1,0 +1,97 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import type { Result as AxeResult } from 'axe-core';
+
+/**
+ * Day 1 — base64-string-converter.
+ *
+ * Verifies the user-visible journey:
+ *   1. Encode round-trip with UTF-8 (CJK, emoji)
+ *   2. Decode round-trip
+ *   3. URL-safe toggle (no `+/=` in output)
+ *   4. Mode tabs (encode/decode)
+ *   5. WCAG 2.1 AA via axe-core
+ *
+ * State is hash-routed; the test verifies that the input lives in the
+ * URL hash (per `feedback_url_parameters` privacy rule).
+ */
+
+const TOOL_PATH = '/developer-tools/#/base64-string-converter';
+
+test.describe('base64-string-converter', () => {
+  test('encode round-trip preserves ASCII', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const input = page.getByLabel(/Base64 converter input/i);
+    const output = page.getByLabel(/Base64 converter output/i);
+    await input.fill('Hello');
+    // Output is debounced; wait for the encoded value to appear.
+    await expect(output).toHaveValue('SGVsbG8=', { timeout: 2000 });
+  });
+
+  test('encode round-trips UTF-8 (CJK)', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const input = page.getByLabel(/Base64 converter input/i);
+    const output = page.getByLabel(/Base64 converter output/i);
+    await input.fill('日本語');
+    await expect(output).toHaveValue('5pel5pys6Kqe', { timeout: 2000 });
+  });
+
+  test('decode mode reverses the encode', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    // Switch to decode mode
+    await page.getByRole('tab', { name: /Decode/i }).click();
+    const input = page.getByLabel(/Base64 converter input/i);
+    const output = page.getByLabel(/Base64 converter output/i);
+    await input.fill('SGVsbG8=');
+    await expect(output).toHaveValue('Hello', { timeout: 2000 });
+  });
+
+  test('URL-safe toggle replaces / with _ and strips =', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const toggle = page.getByLabel(/URL-safe variant/i);
+    await toggle.check();
+    const input = page.getByLabel(/Base64 converter input/i);
+    const output = page.getByLabel(/Base64 converter output/i);
+    await input.fill('subjects?ids[]=1');
+    await expect(output).toHaveValue('c3ViamVjdHM_aWRzW109MQ', { timeout: 2000 });
+  });
+
+  test('input persists in URL hash for sharing', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const input = page.getByLabel(/Base64 converter input/i);
+    await input.fill('share-me');
+    // Wait for the URL to update.
+    await page.waitForFunction(() => window.location.hash.includes('in='));
+    const url = page.url();
+    expect(url).toContain('#/base64-string-converter');
+    expect(url).toContain('in=share-me');
+  });
+});
+
+const A11Y_THEMES = ['clean', 'linear', 'vercel', 'paper', 'swiss', 'aurora', 'matrix'] as const;
+
+test.describe('a11y — base64-string-converter', () => {
+  for (const theme of A11Y_THEMES) {
+    test(`has no detectable WCAG 2.1 AA violations under ${theme}`, async ({ page }) => {
+      await page.goto(TOOL_PATH);
+      await page.evaluate((t) => {
+        localStorage.setItem('dt.theme', t);
+      }, theme);
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'])
+        .analyze();
+
+      expect.soft(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+  }
+});
+
+function formatViolations(violations: readonly AxeResult[]): string {
+  if (violations.length === 0) return 'no violations';
+  return violations
+    .map((v) => `[${v.impact ?? 'unknown'}] ${v.id}: ${v.description}\n  → ${v.helpUrl}`)
+    .join('\n');
+}

--- a/tests/e2e/theme-switcher.spec.ts
+++ b/tests/e2e/theme-switcher.spec.ts
@@ -50,8 +50,11 @@ test.describe('theme switcher', () => {
     expect(stored).toBe('aurora');
   });
 
-  test('renders a usable empty-state when the registry has no tools', async ({ page }) => {
-    await expect(page.locator('.dt-home__empty')).toContainText('No tools yet');
+  test('renders the tool grid once tools are registered', async ({ page }) => {
+    // The registry has shipped tools — the grid replaces the empty state.
+    // Either is acceptable structurally; this test pins the live behavior.
+    await expect(page.locator('.dt-home__grid')).toBeVisible();
+    await expect(page.locator('.dt-home__grid .dt-card').first()).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Bundles two days of work — Day 1 finishing touches on the base64 string
converter plus the Day 2 tool — into one PR per the user's request.
Supersedes #32 (which was the bare Day 1 scaffold; this branch contains
that work plus the additions below).

### UI primitives
- **Paste button** — new clipboard-read primitive with a transient
  "Pasted" feedback state (mirrors the existing copy-button). 6 unit
  tests, including denied-permission path.
- **Topbar language switcher** — flag emoji + locale code (e.g., 🇫🇷 FR).
  Clicking a locale calls `setLocale(code, persist=false)` so the
  override is **session-only**: a hard reload reverts to the
  detected/persisted locale per the user's "until next complete reload"
  request. The whole layout re-mounts on locale change so every
  translate() result reflects the new language.

### Base64 string converter (Day 1, refined)
- Paste button on the source pane, mirroring copy on the result pane.
- Format-aware labels that swap with mode: encode shows **Text → Base64**;
  decode shows **Base64 → Text**. Replaces the generic "Input" / "Output".
- Mode-aware placeholder.
- Per-pane char count (input now displays its count too).
- "How Base64 works" explainer below the workspace, with a worked
  `Cat → Q2F0` example, common uses, and a CTA linking to the new
  Basic Auth tool.

### `base64-basic-auth` (Day 2)
- New tool that builds and reads the
  `Authorization: Basic <base64>` header used by HTTP Basic
  Authentication. UTF-8 round-trip in either field; deep-link with
  credentials in the URL hash (never the query) per the privacy rule.
- **Build** mode: username + password fields with show/hide and per-field
  copy buttons; result pane shows the assembled header with copy + paste.
- **Read** mode: paste a header, get back the decoded credentials. Shows
  a dry-witty hint when the header doesn't parse.
- Self-contained base64 implementation respecting the strict
  tool-isolation rule (no imports from tool 001).

### i18n
- 18 explainer keys + 25 basic-auth keys, translated across all
  **15 locales** in `scripts/translations-data.ts`.
- Runtime now merges authored translations *under* synced JSON, so the
  language switcher actually swaps strings without waiting for a
  Tolgee round-trip. Order: `en` (fallback) ← authored ← synced.

### Bug fixes
- `main.ts`: hoist `activeToolDispose` declaration above `buildLayout()`
  to avoid a TDZ `ReferenceError` on initial mount when the
  locale-change re-render path was added.

## Test plan
- [x] `pnpm test` — 140 / 140 passing (was 117; +23 new)
- [x] `pnpm typecheck` — clean (no `any` / `unknown`)
- [x] `pnpm lint` — 0 errors (warnings only on pre-existing scripts)
- [x] `pnpm build` — green via pre-push hook
- [x] Manual browser verification (Spanish, French, Japanese, Arabic-RTL,
      English): label swap, char count, paste button, explainer, basic
      auth round-trip
- [ ] Playwright e2e (CI will run; new tool needs its own spec — flagging
      as follow-up)
- [ ] Translate explainer + basic-auth keys via Tolgee (`pnpm sync-i18n`)