### PR TITLE
feat(mobile): drawer + hamburger, base64 deep-dive expandables

### DIFF
--- a/scripts/translations-data.ts
+++ b/scripts/translations-data.ts
@@ -33,6 +33,7 @@ const es: Translations = {
   'sidebar.foot.line2': 'Hecho por Pratiyush.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'Repositorio de GitHub',
+  'topbar.menu.aria': 'Abrir menú de navegación',
   'topbar.language.aria': 'Idioma',
   'topbar.language.label': 'Idioma',
   'tool.placeholder.title': 'Herramienta aún no implementada',
@@ -86,6 +87,18 @@ const es: Translations = {
   'tools.base64.explainer.warning':
     'No es cifrado. Cualquiera con la cadena codificada puede decodificarla. Trata base64 como un sobre de transporte, nunca como un secreto.',
   'tools.base64.explainer.tryauth': 'Prueba el ayudante de Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'Paso a paso: codificando "Man" → "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'Observa cómo un trozo de 24 bits se convierte en cuatro índices de 6 bits. Los casos de cola (1 o 2 bytes sobrantes) son la misma idea con relleno `=`.',
+  'tools.base64.deepdive.alphabet.title': 'El alfabeto de 64 caracteres',
+  'tools.base64.deepdive.alphabet.intro':
+    'El base64 estándar (RFC 4648 §4) reserva 64 caracteres ASCII. La variante URL-safe (§5) intercambia dos de ellos para que la salida sobreviva URLs y nombres de archivo.',
+  'tools.base64.deepdive.uses.title': 'Dónde te encontrarás base64 de verdad',
+  'tools.base64.deepdive.uses.intro':
+    'Donde sea que el binario tenga que viajar por un canal solo de texto. Un recorrido corto por los formatos que más lees:',
+  'tools.base64.deepdive.pitfalls.title': 'Cosas que muerden',
+  'tools.base64.deepdive.pitfalls.intro':
+    'La mayoría de "bugs raros de base64" vienen de uno de estos. Échales un ojo antes de depurar.',
   'tools.basicauth.mode.aria': 'Construir o leer cabecera',
   'tools.basicauth.mode.encode': 'Construir',
   'tools.basicauth.mode.decode': 'Leer',
@@ -106,6 +119,7 @@ const es: Translations = {
   'tools.basicauth.paste.header': 'Pegar cabecera',
   'tools.basicauth.invalid':
     'Esa cabecera no se pudo leer. Asegúrate de que tenga la forma `Basic <base64>` y de que el contenido decodificado contenga `:` entre usuario y contraseña.',
+  'tools.basicauth.heading': 'Asistente de HTTP Basic Auth',
   'tools.basicauth.intro':
     'Construye y lee la cabecera `Authorization: Basic <base64>` que usa la autenticación HTTP Basic. Todo en local — las credenciales nunca salen de tu navegador.',
 };
@@ -129,6 +143,7 @@ const fr: Translations = {
   'sidebar.foot.line2': 'Réalisé par Pratiyush.',
   'topbar.theme.aria': 'Thème',
   'topbar.github.aria': 'Dépôt GitHub',
+  'topbar.menu.aria': 'Ouvrir le menu de navigation',
   'topbar.language.aria': 'Langue',
   'topbar.language.label': 'Langue',
   'tool.placeholder.title': 'Outil non encore implémenté',
@@ -182,6 +197,18 @@ const fr: Translations = {
   'tools.base64.explainer.warning':
     'Ce n’est pas du chiffrement. Quiconque a la chaîne encodée peut la décoder. Considère base64 comme une enveloppe de transport, jamais comme un secret.',
   'tools.base64.explainer.tryauth': 'Essayer l’aide Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'Pas à pas : encoder « Man » → « TWFu »',
+  'tools.base64.deepdive.encoding.intro':
+    'Regarde un bloc de 24 bits se transformer en quatre indices de 6 bits. Les cas de fin (1 ou 2 octets restants) suivent la même idée avec un remplissage `=`.',
+  'tools.base64.deepdive.alphabet.title': 'L’alphabet de 64 caractères',
+  'tools.base64.deepdive.alphabet.intro':
+    'Le base64 standard (RFC 4648 §4) réserve 64 caractères ASCII. La variante URL-safe (§5) en remplace deux pour que la sortie survive aux URLs et aux noms de fichiers.',
+  'tools.base64.deepdive.uses.title': 'Où on croise vraiment base64',
+  'tools.base64.deepdive.uses.intro':
+    'Partout où du binaire doit traverser un canal réservé au texte. Petit tour des formats que tu lis le plus :',
+  'tools.base64.deepdive.pitfalls.title': 'Pièges classiques',
+  'tools.base64.deepdive.pitfalls.intro':
+    'La plupart des « bugs base64 bizarres » viennent de l’une de ces causes. Survole-les avant de déboguer.',
   'tools.basicauth.mode.aria': 'Construire ou lire l’en-tête',
   'tools.basicauth.mode.encode': 'Construire',
   'tools.basicauth.mode.decode': 'Lire',
@@ -202,6 +229,7 @@ const fr: Translations = {
   'tools.basicauth.paste.header': 'Coller l’en-tête',
   'tools.basicauth.invalid':
     'Cet en-tête n’a pas pu être lu. Vérifie qu’il a la forme `Basic <base64>` et que la charge décodée contient un `:` entre identifiant et mot de passe.',
+  'tools.basicauth.heading': 'Aide HTTP Basic Auth',
   'tools.basicauth.intro':
     'Construit et lit l’en-tête `Authorization: Basic <base64>` utilisé par l’authentification HTTP Basic. Tout en local — les identifiants ne quittent jamais ton navigateur.',
 };
@@ -225,6 +253,7 @@ const de: Translations = {
   'sidebar.foot.line2': 'Erstellt von Pratiyush.',
   'topbar.theme.aria': 'Thema',
   'topbar.github.aria': 'GitHub-Repository',
+  'topbar.menu.aria': 'Navigationsmenü öffnen',
   'topbar.language.aria': 'Sprache',
   'topbar.language.label': 'Sprache',
   'tool.placeholder.title': 'Tool noch nicht implementiert',
@@ -278,6 +307,18 @@ const de: Translations = {
   'tools.base64.explainer.warning':
     'Keine Verschlüsselung. Wer den kodierten String hat, kann ihn zurückdekodieren. Behandle base64 als Transportumschlag, nie als Geheimnis.',
   'tools.base64.explainer.tryauth': 'Probier den Basic-Auth-Helfer →',
+  'tools.base64.deepdive.encoding.title': 'Schritt für Schritt: "Man" → "TWFu" kodieren',
+  'tools.base64.deepdive.encoding.intro':
+    'Sieh zu, wie ein 24-Bit-Block in vier 6-Bit-Indizes zerfällt. Die Endfälle (1 oder 2 übrige Bytes) sind dieselbe Idee mit `=`-Padding.',
+  'tools.base64.deepdive.alphabet.title': 'Das 64-Zeichen-Alphabet',
+  'tools.base64.deepdive.alphabet.intro':
+    'Standard-base64 (RFC 4648 §4) reserviert 64 ASCII-Zeichen. Die URL-sichere Variante (§5) tauscht zwei davon aus, damit die Ausgabe URLs und Dateinamen übersteht.',
+  'tools.base64.deepdive.uses.title': 'Wo man base64 tatsächlich trifft',
+  'tools.base64.deepdive.uses.intro':
+    'Überall dort, wo Binärdaten durch einen reinen Textkanal müssen. Eine Kurztour durch die Formate, die du am meisten liest:',
+  'tools.base64.deepdive.pitfalls.title': 'Klassische Fallstricke',
+  'tools.base64.deepdive.pitfalls.intro':
+    'Die meisten "merkwürdigen base64-Bugs" kommen aus einer dieser Quellen. Vor dem Debuggen kurz überfliegen.',
   'tools.basicauth.mode.aria': 'Header bauen oder lesen',
   'tools.basicauth.mode.encode': 'Bauen',
   'tools.basicauth.mode.decode': 'Lesen',
@@ -298,6 +339,7 @@ const de: Translations = {
   'tools.basicauth.paste.header': 'Header einfügen',
   'tools.basicauth.invalid':
     'Dieser Header ließ sich nicht lesen. Stelle sicher, dass er `Basic <base64>` lautet und die dekodierte Nutzlast einen `:` zwischen Benutzer und Passwort enthält.',
+  'tools.basicauth.heading': 'HTTP-Basic-Auth-Helfer',
   'tools.basicauth.intro':
     'Baut und liest den Header `Authorization: Basic <base64>`, den HTTP Basic Authentication verwendet. Alles lokal — die Anmeldedaten verlassen den Browser nie.',
 };
@@ -321,6 +363,7 @@ const pt: Translations = {
   'sidebar.foot.line2': 'Feito por Pratiyush.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'Repositório do GitHub',
+  'topbar.menu.aria': 'Abrir menu de navegação',
   'topbar.language.aria': 'Idioma',
   'topbar.language.label': 'Idioma',
   'tool.placeholder.title': 'Ferramenta ainda não implementada',
@@ -374,6 +417,18 @@ const pt: Translations = {
   'tools.base64.explainer.warning':
     'Não é criptografia. Qualquer pessoa com a string codificada consegue decodificar de volta. Trate base64 como envelope de transporte, nunca como segredo.',
   'tools.base64.explainer.tryauth': 'Experimenta o ajudante de Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'Passo a passo: codificar "Man" → "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'Vê um bloco de 24 bits virar quatro índices de 6 bits. Os casos de cauda (1 ou 2 bytes restantes) são a mesma ideia com preenchimento `=`.',
+  'tools.base64.deepdive.alphabet.title': 'O alfabeto de 64 caracteres',
+  'tools.base64.deepdive.alphabet.intro':
+    'O base64 padrão (RFC 4648 §4) reserva 64 caracteres ASCII. A variante URL-safe (§5) troca dois deles para que a saída sobreviva a URLs e nomes de ficheiro.',
+  'tools.base64.deepdive.uses.title': 'Onde encontras base64 a sério',
+  'tools.base64.deepdive.uses.intro':
+    'Em qualquer canal só de texto onde precise passar binário. Uma volta rápida pelos formatos que mais lês:',
+  'tools.base64.deepdive.pitfalls.title': 'Coisas que mordem',
+  'tools.base64.deepdive.pitfalls.intro':
+    'A maior parte dos "bugs estranhos de base64" vem de um destes. Lê antes de ir depurar.',
   'tools.basicauth.mode.aria': 'Construir ou ler o cabeçalho',
   'tools.basicauth.mode.encode': 'Construir',
   'tools.basicauth.mode.decode': 'Ler',
@@ -394,6 +449,7 @@ const pt: Translations = {
   'tools.basicauth.paste.header': 'Colar cabeçalho',
   'tools.basicauth.invalid':
     'Esse cabeçalho não pôde ser lido. Confere se tem o formato `Basic <base64>` e se o conteúdo decodificado contém `:` entre usuário e senha.',
+  'tools.basicauth.heading': 'Ajudante HTTP Basic Auth',
   'tools.basicauth.intro':
     'Constrói e lê o cabeçalho `Authorization: Basic <base64>` usado pela autenticação HTTP Basic. Tudo local — as credenciais nunca saem do seu navegador.',
 };
@@ -417,6 +473,7 @@ const it: Translations = {
   'sidebar.foot.line2': 'Realizzato da Pratiyush.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'Repository GitHub',
+  'topbar.menu.aria': 'Apri menu di navigazione',
   'topbar.language.aria': 'Lingua',
   'topbar.language.label': 'Lingua',
   'tool.placeholder.title': 'Strumento non ancora implementato',
@@ -470,6 +527,18 @@ const it: Translations = {
   'tools.base64.explainer.warning':
     'Non è cifratura. Chiunque abbia la stringa codificata può decodificarla. Tratta base64 come una busta di trasporto, mai come un segreto.',
   'tools.base64.explainer.tryauth': 'Prova l’aiutante Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'Passo passo: codificare "Man" → "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'Guarda un blocco da 24 bit trasformarsi in quattro indici da 6 bit. I casi di coda (1 o 2 byte residui) sono la stessa idea con padding `=`.',
+  'tools.base64.deepdive.alphabet.title': 'L’alfabeto da 64 caratteri',
+  'tools.base64.deepdive.alphabet.intro':
+    'Il base64 standard (RFC 4648 §4) riserva 64 caratteri ASCII. La variante URL-safe (§5) ne scambia due perché l’output sopravviva a URL e nomi file.',
+  'tools.base64.deepdive.uses.title': 'Dove incontri base64 davvero',
+  'tools.base64.deepdive.uses.intro':
+    'Ovunque il binario debba viaggiare in un canale solo testo. Un tour rapido dei formati che leggi di più:',
+  'tools.base64.deepdive.pitfalls.title': 'Cose che mordono',
+  'tools.base64.deepdive.pitfalls.intro':
+    'La maggior parte dei "bug strani di base64" nasce da uno di questi. Dai un’occhiata prima di metterti a debuggare.',
   'tools.basicauth.mode.aria': 'Costruisci o leggi l’header',
   'tools.basicauth.mode.encode': 'Costruisci',
   'tools.basicauth.mode.decode': 'Leggi',
@@ -490,6 +559,7 @@ const it: Translations = {
   'tools.basicauth.paste.header': 'Incolla header',
   'tools.basicauth.invalid':
     'Questo header non è stato letto. Assicurati che abbia la forma `Basic <base64>` e che il payload decodificato contenga `:` tra utente e password.',
+  'tools.basicauth.heading': 'Aiutante HTTP Basic Auth',
   'tools.basicauth.intro':
     'Costruisce e legge l’header `Authorization: Basic <base64>` usato dall’autenticazione HTTP Basic. Tutto in locale — le credenziali non lasciano mai il tuo browser.',
 };
@@ -513,6 +583,7 @@ const nl: Translations = {
   'sidebar.foot.line2': 'Gemaakt door Pratiyush.',
   'topbar.theme.aria': 'Thema',
   'topbar.github.aria': 'GitHub-repository',
+  'topbar.menu.aria': 'Navigatiemenu openen',
   'topbar.language.aria': 'Taal',
   'topbar.language.label': 'Taal',
   'tool.placeholder.title': 'Tool nog niet geïmplementeerd',
@@ -566,6 +637,18 @@ const nl: Translations = {
   'tools.base64.explainer.warning':
     'Geen versleuteling. Iedereen met de gecodeerde string kan hem terug decoderen. Behandel base64 als transportenvelop, nooit als geheim.',
   'tools.base64.explainer.tryauth': 'Probeer de Basic-Auth-helper →',
+  'tools.base64.deepdive.encoding.title': 'Stap voor stap: "Man" → "TWFu" coderen',
+  'tools.base64.deepdive.encoding.intro':
+    'Kijk hoe een 24-bits blok in vier 6-bits indices uiteenvalt. De staartgevallen (1 of 2 overgebleven bytes) zijn hetzelfde idee met `=`-opvulling.',
+  'tools.base64.deepdive.alphabet.title': 'Het alfabet van 64 tekens',
+  'tools.base64.deepdive.alphabet.intro':
+    'Standaard base64 (RFC 4648 §4) reserveert 64 ASCII-tekens. De URL-veilige variant (§5) wisselt er twee zodat de uitvoer URL’s en bestandsnamen overleeft.',
+  'tools.base64.deepdive.uses.title': 'Waar je base64 echt tegenkomt',
+  'tools.base64.deepdive.uses.intro':
+    'Overal waar binair door een enkel-tekstkanaal moet. Een korte rondleiding langs de formaten die je het meest leest:',
+  'tools.base64.deepdive.pitfalls.title': 'Dingen die bijten',
+  'tools.base64.deepdive.pitfalls.intro':
+    'De meeste "rare base64-bugs" komen uit één van deze. Lees ze door voordat je debugt.',
   'tools.basicauth.mode.aria': 'Header bouwen of lezen',
   'tools.basicauth.mode.encode': 'Bouwen',
   'tools.basicauth.mode.decode': 'Lezen',
@@ -586,6 +669,7 @@ const nl: Translations = {
   'tools.basicauth.paste.header': 'Header plakken',
   'tools.basicauth.invalid':
     'Die header kon niet gelezen worden. Zorg dat hij eruitziet als `Basic <base64>` en dat de gedecodeerde inhoud een `:` bevat tussen gebruikersnaam en wachtwoord.',
+  'tools.basicauth.heading': 'HTTP-Basic-Auth-helper',
   'tools.basicauth.intro':
     'Bouwt en leest de `Authorization: Basic <base64>`-header die HTTP Basic Authentication gebruikt. Alles lokaal — gegevens verlaten je browser nooit.',
 };
@@ -609,6 +693,7 @@ const pl: Translations = {
   'sidebar.foot.line2': 'Stworzone przez Pratiyusha.',
   'topbar.theme.aria': 'Motyw',
   'topbar.github.aria': 'Repozytorium GitHub',
+  'topbar.menu.aria': 'Otwórz menu nawigacji',
   'topbar.language.aria': 'Język',
   'topbar.language.label': 'Język',
   'tool.placeholder.title': 'Narzędzie jeszcze nie zaimplementowane',
@@ -662,6 +747,18 @@ const pl: Translations = {
   'tools.base64.explainer.warning':
     'To nie szyfrowanie. Każdy z zakodowanym ciągiem może go zdekodować. Traktuj base64 jako kopertę transportową, nigdy jako sekret.',
   'tools.base64.explainer.tryauth': 'Wypróbuj pomocnika Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'Krok po kroku: kodowanie "Man" → "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'Patrz, jak 24-bitowy blok rozpada się na cztery 6-bitowe indeksy. Przypadki ogona (1 lub 2 pozostałe bajty) to ta sama idea z dopełnieniem `=`.',
+  'tools.base64.deepdive.alphabet.title': 'Alfabet 64 znaków',
+  'tools.base64.deepdive.alphabet.intro':
+    'Standardowy base64 (RFC 4648 §4) rezerwuje 64 znaki ASCII. Wariant URL-safe (§5) podmienia dwa z nich, aby wyjście przetrwało URL-e i nazwy plików.',
+  'tools.base64.deepdive.uses.title': 'Gdzie naprawdę spotkasz base64',
+  'tools.base64.deepdive.uses.intro':
+    'Wszędzie tam, gdzie binarne dane muszą jechać kanałem tylko-tekstowym. Krótki przegląd formatów, które czytasz najczęściej:',
+  'tools.base64.deepdive.pitfalls.title': 'Rzeczy, które gryzą',
+  'tools.base64.deepdive.pitfalls.intro':
+    'Większość "dziwnych bugów base64" pochodzi z jednej z tych przyczyn. Przeleć wzrokiem przed debugowaniem.',
   'tools.basicauth.mode.aria': 'Zbuduj lub odczytaj nagłówek',
   'tools.basicauth.mode.encode': 'Zbuduj',
   'tools.basicauth.mode.decode': 'Odczytaj',
@@ -682,6 +779,7 @@ const pl: Translations = {
   'tools.basicauth.paste.header': 'Wklej nagłówek',
   'tools.basicauth.invalid':
     'Tego nagłówka nie udało się odczytać. Upewnij się, że ma postać `Basic <base64>`, a zdekodowany ładunek zawiera `:` między użytkownikiem a hasłem.',
+  'tools.basicauth.heading': 'Pomocnik HTTP Basic Auth',
   'tools.basicauth.intro':
     'Buduje i odczytuje nagłówek `Authorization: Basic <base64>` używany przez uwierzytelnianie HTTP Basic. Wszystko lokalnie — dane nigdy nie opuszczają Twojej przeglądarki.',
 };
@@ -705,6 +803,7 @@ const ru: Translations = {
   'sidebar.foot.line2': 'Сделано Pratiyush.',
   'topbar.theme.aria': 'Тема',
   'topbar.github.aria': 'Репозиторий GitHub',
+  'topbar.menu.aria': 'Открыть меню навигации',
   'topbar.language.aria': 'Язык',
   'topbar.language.label': 'Язык',
   'tool.placeholder.title': 'Инструмент ещё не реализован',
@@ -758,6 +857,18 @@ const ru: Translations = {
   'tools.base64.explainer.warning':
     'Это не шифрование. Любой с закодированной строкой раскодирует её обратно. Считайте base64 транспортным конвертом, не секретом.',
   'tools.base64.explainer.tryauth': 'Попробуйте помощник Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'По шагам: кодируем "Man" → "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'Смотрите, как 24-битный блок превращается в четыре 6-битных индекса. Хвостовые случаи (1 или 2 оставшихся байта) — та же идея с заполнением `=`.',
+  'tools.base64.deepdive.alphabet.title': 'Алфавит из 64 символов',
+  'tools.base64.deepdive.alphabet.intro':
+    'Стандартный base64 (RFC 4648 §4) резервирует 64 ASCII-символа. URL-безопасный вариант (§5) меняет два из них, чтобы результат пережил URL и имена файлов.',
+  'tools.base64.deepdive.uses.title': 'Где реально встречается base64',
+  'tools.base64.deepdive.uses.intro':
+    'Везде, где двоичные данные должны проехать по чисто текстовому каналу. Короткий обзор форматов, которые вы читаете чаще всего:',
+  'tools.base64.deepdive.pitfalls.title': 'То, что кусается',
+  'tools.base64.deepdive.pitfalls.intro':
+    'Большинство "странных багов base64" — отсюда. Пробегите глазами перед отладкой.',
   'tools.basicauth.mode.aria': 'Собрать или прочитать заголовок',
   'tools.basicauth.mode.encode': 'Собрать',
   'tools.basicauth.mode.decode': 'Прочитать',
@@ -778,6 +889,7 @@ const ru: Translations = {
   'tools.basicauth.paste.header': 'Вставить заголовок',
   'tools.basicauth.invalid':
     'Этот заголовок не разобрался. Убедитесь, что он имеет вид `Basic <base64>` и в декодированной нагрузке есть `:` между логином и паролем.',
+  'tools.basicauth.heading': 'Помощник HTTP Basic Auth',
   'tools.basicauth.intro':
     'Собирает и разбирает заголовок `Authorization: Basic <base64>`, используемый HTTP Basic Authentication. Всё локально — учётные данные не покидают браузер.',
 };
@@ -801,6 +913,7 @@ const tr: Translations = {
   'sidebar.foot.line2': 'Pratiyush tarafından yapıldı.',
   'topbar.theme.aria': 'Tema',
   'topbar.github.aria': 'GitHub deposu',
+  'topbar.menu.aria': 'Gezinme menüsünü aç',
   'topbar.language.aria': 'Dil',
   'topbar.language.label': 'Dil',
   'tool.placeholder.title': 'Araç henüz uygulanmadı',
@@ -854,6 +967,18 @@ const tr: Translations = {
   'tools.base64.explainer.warning':
     'Şifreleme değildir. Kodlanmış diziye sahip olan herkes geri çözebilir. Base64’ü taşıma zarfı say, asla sır olarak kullanma.',
   'tools.base64.explainer.tryauth': 'Basic Auth yardımcısını dene →',
+  'tools.base64.deepdive.encoding.title': 'Adım adım: "Man" → "TWFu" kodlama',
+  'tools.base64.deepdive.encoding.intro':
+    '24 bitlik bir bloğun dört adet 6 bitlik indekse nasıl dönüştüğüne bak. Kuyruk durumları (1 veya 2 artık bayt) `=` dolgusuyla aynı fikrin uzantısı.',
+  'tools.base64.deepdive.alphabet.title': '64 karakterlik alfabe',
+  'tools.base64.deepdive.alphabet.intro':
+    'Standart base64 (RFC 4648 §4) 64 ASCII karakter ayırır. URL-güvenli varyant (§5) bunlardan ikisini değiştirir; çıktı URL ve dosya adlarında bozulmaz.',
+  'tools.base64.deepdive.uses.title': 'Base64’ü gerçekten nerede görürsün',
+  'tools.base64.deepdive.uses.intro':
+    'İkilinin yalnızca metin kanalında yolculuk etmesi gerektiği her yerde. En çok okuduğun biçimlere kısa bir tur:',
+  'tools.base64.deepdive.pitfalls.title': 'Isıran şeyler',
+  'tools.base64.deepdive.pitfalls.intro':
+    '"Garip base64 hatalarının" çoğu bu listenin birinden çıkar. Hata ayıklamadan önce göz at.',
   'tools.basicauth.mode.aria': 'Başlık oluştur veya oku',
   'tools.basicauth.mode.encode': 'Oluştur',
   'tools.basicauth.mode.decode': 'Oku',
@@ -874,6 +999,7 @@ const tr: Translations = {
   'tools.basicauth.paste.header': 'Başlığı yapıştır',
   'tools.basicauth.invalid':
     'O başlık çözülemedi. `Basic <base64>` formatında olduğundan ve çözülmüş içerikte kullanıcı ile şifre arasında `:` bulunduğundan emin ol.',
+  'tools.basicauth.heading': 'HTTP Basic Auth yardımcısı',
   'tools.basicauth.intro':
     'HTTP Basic Authentication’ın kullandığı `Authorization: Basic <base64>` başlığını oluşturur ve okur. Hepsi cihazda — kimlik bilgileri tarayıcından çıkmaz.',
 };
@@ -897,6 +1023,7 @@ const ja: Translations = {
   'sidebar.foot.line2': 'Pratiyush が制作。',
   'topbar.theme.aria': 'テーマ',
   'topbar.github.aria': 'GitHub リポジトリ',
+  'topbar.menu.aria': 'ナビゲーションメニューを開く',
   'topbar.language.aria': '言語',
   'topbar.language.label': '言語',
   'tool.placeholder.title': 'ツールはまだ実装されていません',
@@ -950,6 +1077,18 @@ const ja: Translations = {
   'tools.base64.explainer.warning':
     '暗号ではありません。エンコード文字列を持つ人なら誰でもデコードできます。Base64 は輸送用の封筒として扱い、決して秘密として使わないこと。',
   'tools.base64.explainer.tryauth': 'Basic Auth ヘルパーを試す →',
+  'tools.base64.deepdive.encoding.title': 'ステップ解説：「Man」→「TWFu」のエンコード',
+  'tools.base64.deepdive.encoding.intro':
+    '24 ビットのかたまりが 4 つの 6 ビットインデックスに変わる様子を追います。残りが 1 〜 2 バイトの末尾ケースは、同じ理屈に `=` パディングが付くだけです。',
+  'tools.base64.deepdive.alphabet.title': '64 文字のアルファベット',
+  'tools.base64.deepdive.alphabet.intro':
+    '標準 base64（RFC 4648 §4）は 64 個の ASCII 文字を割り当てます。URL 安全な変種（§5）はそのうち 2 文字を入れ替えて、URL やファイル名でも壊れないようにします。',
+  'tools.base64.deepdive.uses.title': 'Base64 に実際に出会う場所',
+  'tools.base64.deepdive.uses.intro':
+    'バイナリがテキストのみの経路を旅する必要があるあらゆる場所。よく目にする形式を駆け足で：',
+  'tools.base64.deepdive.pitfalls.title': '噛みつく罠',
+  'tools.base64.deepdive.pitfalls.intro':
+    '「base64 の妙なバグ」はだいたいここに書かれた原因のどれかです。デバッグの前に一読を。',
   'tools.basicauth.mode.aria': 'ヘッダを作成または読む',
   'tools.basicauth.mode.encode': '作成',
   'tools.basicauth.mode.decode': '読み取り',
@@ -970,6 +1109,7 @@ const ja: Translations = {
   'tools.basicauth.paste.header': 'ヘッダを貼り付け',
   'tools.basicauth.invalid':
     'そのヘッダは解析できませんでした。形式が `Basic <base64>` で、デコード後のペイロードのユーザー名とパスワードの間に `:` があることを確認してください。',
+  'tools.basicauth.heading': 'HTTP Basic 認証ヘルパー',
   'tools.basicauth.intro':
     'HTTP Basic 認証で使う `Authorization: Basic <base64>` ヘッダを作成・読み取りします。すべて端末内で完結 — 資格情報はブラウザを離れません。',
 };
@@ -993,6 +1133,7 @@ const zh: Translations = {
   'sidebar.foot.line2': '由 Pratiyush 制作。',
   'topbar.theme.aria': '主题',
   'topbar.github.aria': 'GitHub 仓库',
+  'topbar.menu.aria': '打开导航菜单',
   'topbar.language.aria': '语言',
   'topbar.language.label': '语言',
   'tool.placeholder.title': '工具尚未实现',
@@ -1041,6 +1182,17 @@ const zh: Translations = {
   'tools.base64.explainer.warning':
     '它不是加密。任何拿到编码字符串的人都能把它解回来。把 base64 当成运输信封，永远别当作秘密。',
   'tools.base64.explainer.tryauth': '试试 Basic Auth 助手 →',
+  'tools.base64.deepdive.encoding.title': '一步步：把 "Man" 编码成 "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    '看着一段 24 位的数据被切成 4 个 6 位索引。尾部情况（剩 1 或 2 个字节）思路一样，只是加上 `=` 填充。',
+  'tools.base64.deepdive.alphabet.title': '64 字符字母表',
+  'tools.base64.deepdive.alphabet.intro':
+    '标准 base64（RFC 4648 §4）保留 64 个 ASCII 字符。URL 安全版本（§5）替换其中两个，让输出能在 URL 和文件名里安然通过。',
+  'tools.base64.deepdive.uses.title': '你真正会遇见 base64 的地方',
+  'tools.base64.deepdive.uses.intro':
+    '凡是二进制要走纯文本通道的地方都有。下面是你最常遇到的几种格式：',
+  'tools.base64.deepdive.pitfalls.title': '会咬人的小坑',
+  'tools.base64.deepdive.pitfalls.intro': '大多数 "base64 怪 bug" 都出自下面之一。调试前先扫一遍。',
   'tools.basicauth.mode.aria': '生成或读取头',
   'tools.basicauth.mode.encode': '生成',
   'tools.basicauth.mode.decode': '读取',
@@ -1061,6 +1213,7 @@ const zh: Translations = {
   'tools.basicauth.paste.header': '粘贴头',
   'tools.basicauth.invalid':
     '没解析出这个头。请确认它形如 `Basic <base64>`，并且解码后的内容里用户名和密码之间有 `:`。',
+  'tools.basicauth.heading': 'HTTP Basic 认证助手',
   'tools.basicauth.intro':
     '生成并读取 HTTP Basic 认证使用的 `Authorization: Basic <base64>` 头。全程本地 — 凭据不会离开你的浏览器。',
 };
@@ -1084,6 +1237,7 @@ const ko: Translations = {
   'sidebar.foot.line2': 'Pratiyush 제작.',
   'topbar.theme.aria': '테마',
   'topbar.github.aria': 'GitHub 리포지토리',
+  'topbar.menu.aria': '내비게이션 메뉴 열기',
   'topbar.language.aria': '언어',
   'topbar.language.label': '언어',
   'tool.placeholder.title': '도구가 아직 구현되지 않았습니다',
@@ -1136,6 +1290,18 @@ const ko: Translations = {
   'tools.base64.explainer.warning':
     '암호화가 아닙니다. 인코딩된 문자열을 가진 누구나 다시 디코딩할 수 있습니다. base64는 운송 봉투로 다루고 비밀로 쓰지 마세요.',
   'tools.base64.explainer.tryauth': 'Basic Auth 헬퍼 시도 →',
+  'tools.base64.deepdive.encoding.title': '단계별: "Man"을 "TWFu"로 인코딩',
+  'tools.base64.deepdive.encoding.intro':
+    '24비트 한 덩어리가 6비트 인덱스 4개로 어떻게 쪼개지는지 따라가 보세요. 꼬리 사례(1~2바이트가 남는 경우)는 같은 아이디어에 `=` 패딩이 붙는 것 뿐입니다.',
+  'tools.base64.deepdive.alphabet.title': '64자 알파벳',
+  'tools.base64.deepdive.alphabet.intro':
+    '표준 base64(RFC 4648 §4)는 64개의 ASCII 문자를 예약합니다. URL 안전 변형(§5)은 그중 두 글자를 바꿔서 URL과 파일 이름을 살아남게 합니다.',
+  'tools.base64.deepdive.uses.title': 'base64를 실제로 만나는 곳',
+  'tools.base64.deepdive.uses.intro':
+    '바이너리가 텍스트 전용 경로를 지나야 하는 모든 곳. 가장 자주 읽게 되는 형식들을 짧게 둘러보기:',
+  'tools.base64.deepdive.pitfalls.title': '무는 함정',
+  'tools.base64.deepdive.pitfalls.intro':
+    '"이상한 base64 버그"의 대부분은 아래 항목 중 하나에서 옵니다. 디버그 전에 훑어보세요.',
   'tools.basicauth.mode.aria': '헤더 생성 또는 읽기',
   'tools.basicauth.mode.encode': '생성',
   'tools.basicauth.mode.decode': '읽기',
@@ -1156,6 +1322,7 @@ const ko: Translations = {
   'tools.basicauth.paste.header': '헤더 붙여넣기',
   'tools.basicauth.invalid':
     '그 헤더를 해석할 수 없었습니다. `Basic <base64>` 형식인지, 디코딩된 페이로드의 사용자명과 비밀번호 사이에 `:`가 있는지 확인하세요.',
+  'tools.basicauth.heading': 'HTTP Basic 인증 헬퍼',
   'tools.basicauth.intro':
     'HTTP Basic 인증이 사용하는 `Authorization: Basic <base64>` 헤더를 생성하고 읽습니다. 모두 로컬에서 — 자격 증명이 브라우저를 떠나지 않습니다.',
 };
@@ -1179,6 +1346,7 @@ const hi: Translations = {
   'sidebar.foot.line2': 'Pratiyush द्वारा बनाया गया।',
   'topbar.theme.aria': 'थीम',
   'topbar.github.aria': 'GitHub रिपॉजिटरी',
+  'topbar.menu.aria': 'नेविगेशन मेन्यू खोलें',
   'topbar.language.aria': 'भाषा',
   'topbar.language.label': 'भाषा',
   'tool.placeholder.title': 'टूल अभी तक लागू नहीं किया गया',
@@ -1232,6 +1400,18 @@ const hi: Translations = {
   'tools.base64.explainer.warning':
     'यह एन्क्रिप्शन नहीं है। एनकोडेड स्ट्रिंग रखने वाला कोई भी इसे वापस डिकोड कर सकता है। base64 को परिवहन का लिफाफा मानो, राज़ नहीं।',
   'tools.base64.explainer.tryauth': 'Basic Auth मददगार आज़माएँ →',
+  'tools.base64.deepdive.encoding.title': 'क़दम-दर-क़दम: "Man" को "TWFu" में बदलना',
+  'tools.base64.deepdive.encoding.intro':
+    'देखो कैसे 24-बिट का एक टुकड़ा 6-बिट के चार इंडेक्स में बँट जाता है। पूँछ वाले मामले (1 या 2 बाइट बचे हों) यही विचार हैं, बस `=` पैडिंग के साथ।',
+  'tools.base64.deepdive.alphabet.title': '64 वर्णों की वर्णमाला',
+  'tools.base64.deepdive.alphabet.intro':
+    'मानक base64 (RFC 4648 §4) 64 ASCII वर्ण आरक्षित करता है। URL-सुरक्षित प्रकार (§5) इनमें दो को बदल देता है ताकि आउटपुट URL और फ़ाइल नामों में भी टिक जाए।',
+  'tools.base64.deepdive.uses.title': 'base64 असल में कहाँ मिलेगा',
+  'tools.base64.deepdive.uses.intro':
+    'जहाँ भी बाइनरी को सिर्फ़-टेक्स्ट चैनल से जाना हो। जिन फ़ॉर्मैट्स को सबसे ज़्यादा पढ़ोगे उनकी झलक:',
+  'tools.base64.deepdive.pitfalls.title': 'काटने वाली बातें',
+  'tools.base64.deepdive.pitfalls.intro':
+    '"base64 की अजीब बग" अक्सर इन्हीं में से किसी एक से आती है। डिबग शुरू करने से पहले एक बार देख लो।',
   'tools.basicauth.mode.aria': 'हेडर बनाओ या पढ़ो',
   'tools.basicauth.mode.encode': 'बनाओ',
   'tools.basicauth.mode.decode': 'पढ़ो',
@@ -1252,6 +1432,7 @@ const hi: Translations = {
   'tools.basicauth.paste.header': 'हेडर पेस्ट',
   'tools.basicauth.invalid':
     'वह हेडर पार्स नहीं हुआ। जाँचो कि वह `Basic <base64>` जैसा दिखता है और डिकोड की गई सामग्री में उपयोगकर्ता नाम और पासवर्ड के बीच `:` है।',
+  'tools.basicauth.heading': 'HTTP Basic Auth मददगार',
   'tools.basicauth.intro':
     'HTTP Basic प्रमाणीकरण का `Authorization: Basic <base64>` हेडर बनाता और पढ़ता है। सब डिवाइस पर — क्रेडेंशियल ब्राउज़र से बाहर नहीं जाते।',
 };
@@ -1275,6 +1456,7 @@ const ar: Translations = {
   'sidebar.foot.line2': 'صنع بواسطة Pratiyush.',
   'topbar.theme.aria': 'السمة',
   'topbar.github.aria': 'مستودع GitHub',
+  'topbar.menu.aria': 'افتح قائمة التنقل',
   'topbar.language.aria': 'اللغة',
   'topbar.language.label': 'اللغة',
   'tool.placeholder.title': 'الأداة لم تُنفّذ بعد',
@@ -1326,6 +1508,18 @@ const ar: Translations = {
   'tools.base64.explainer.warning':
     'ليس تشفيرًا. أيّ شخص بحوزته السلسلة المُشفّرة يستطيع فكّها. عامل base64 كمظروف نقل، ولا تستخدمه سرًّا.',
   'tools.base64.explainer.tryauth': 'جرّب مساعد Basic Auth →',
+  'tools.base64.deepdive.encoding.title': 'خطوة بخطوة: ترميز "Man" إلى "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'تابع كيف تتحول كتلة 24-بِتّاً إلى أربع فهارس من 6 بِتّات. حالات الذيل (1 أو 2 بايت متبقية) هي الفكرة نفسها مع حشوة `=`.',
+  'tools.base64.deepdive.alphabet.title': 'أبجدية الـ 64 محرفًا',
+  'tools.base64.deepdive.alphabet.intro':
+    'يحجز base64 المعياري (RFC 4648 §4) 64 محرفًا من ASCII. المتغيّر الآمن للروابط (§5) يبدّل اثنين منها لتنجو المخرجات في الروابط وأسماء الملفات.',
+  'tools.base64.deepdive.uses.title': 'أين تلتقي base64 فعلاً',
+  'tools.base64.deepdive.uses.intro':
+    'في أي مكان يحتاج فيه الثنائي إلى عبور قناة نصية فقط. جولة سريعة على الصيغ الأكثر شيوعًا:',
+  'tools.base64.deepdive.pitfalls.title': 'أمور تعض',
+  'tools.base64.deepdive.pitfalls.intro':
+    'معظم "أخطاء base64 الغريبة" تنبثق من أحد هذه الأسباب. تصفّح القائمة قبل تنقيح الكود.',
   'tools.basicauth.mode.aria': 'بناء أو قراءة الترويسة',
   'tools.basicauth.mode.encode': 'بناء',
   'tools.basicauth.mode.decode': 'قراءة',
@@ -1346,6 +1540,7 @@ const ar: Translations = {
   'tools.basicauth.paste.header': 'الصق الترويسة',
   'tools.basicauth.invalid':
     'هذه الترويسة لم تُحلّل. تأكّد أن صيغتها `Basic <base64>` وأن المحتوى المفكوك يحوي `:` بين المستخدم وكلمة المرور.',
+  'tools.basicauth.heading': 'مساعد HTTP Basic Auth',
   'tools.basicauth.intro':
     'يُنشئ ويقرأ ترويسة `Authorization: Basic <base64>` التي يستخدمها مصادقة HTTP Basic. كلّه محلي — لا تغادر بياناتك المتصفّح.',
 };

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -23,6 +23,7 @@ const en: Translations = {
 
   'topbar.theme.aria': 'Theme',
   'topbar.github.aria': 'GitHub repository',
+  'topbar.menu.aria': 'Open navigation menu',
   'topbar.language.aria': 'Language',
   'topbar.language.label': 'Language',
 
@@ -81,6 +82,18 @@ const en: Translations = {
   'tools.base64.explainer.warning':
     'Not encryption. Anyone with the encoded string can decode it back. Treat base64 as an envelope for transport, never as a secret.',
   'tools.base64.explainer.tryauth': 'Try the Basic Auth helper →',
+  'tools.base64.deepdive.encoding.title': 'Step-by-step: encoding "Man" → "TWFu"',
+  'tools.base64.deepdive.encoding.intro':
+    'Watch one 24-bit chunk turn into four 6-bit indices. The tail cases (1 or 2 leftover bytes) are the same idea with `=` padding.',
+  'tools.base64.deepdive.alphabet.title': 'The 64-character alphabet',
+  'tools.base64.deepdive.alphabet.intro':
+    'Standard base64 (RFC 4648 §4) reserves 64 ASCII characters. The URL-safe variant (§5) swaps two of them so the output survives URLs and filenames.',
+  'tools.base64.deepdive.uses.title': 'Where you actually meet base64',
+  'tools.base64.deepdive.uses.intro':
+    'Anywhere binary needs to ride through a text-only channel. A short tour of the formats you read most:',
+  'tools.base64.deepdive.pitfalls.title': 'Things that bite',
+  'tools.base64.deepdive.pitfalls.intro':
+    'Most "weird base64 bugs" come from one of these. Skim before you debug.',
 
   'tools.basicauth.mode.aria': 'Build header or read header',
   'tools.basicauth.mode.encode': 'Build',
@@ -102,6 +115,7 @@ const en: Translations = {
   'tools.basicauth.paste.header': 'Paste header',
   'tools.basicauth.invalid':
     'That header did not parse. Make sure it looks like `Basic <base64>` and the decoded payload contains a `:` between username and password.',
+  'tools.basicauth.heading': 'HTTP Basic Auth helper',
   'tools.basicauth.intro':
     'Builds and reads the `Authorization: Basic <base64>` header used by HTTP Basic Authentication. All on-device — credentials never leave your browser.',
 };

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -27,6 +27,7 @@ export interface Translations {
 
   'topbar.theme.aria': string;
   'topbar.github.aria': string;
+  'topbar.menu.aria': string;
 
   'tool.placeholder.title': string;
   'tool.placeholder.body': string;
@@ -80,6 +81,17 @@ export interface Translations {
   'tools.base64.explainer.uses': string;
   'tools.base64.explainer.warning': string;
   'tools.base64.explainer.tryauth': string;
+  // Deep-dive expandable sections — click to reveal a technical breakdown.
+  // Headings are translated; the long-form bodies live as inline content
+  // (universal code blocks, hex/binary tables) inside render.ts.
+  'tools.base64.deepdive.encoding.title': string;
+  'tools.base64.deepdive.encoding.intro': string;
+  'tools.base64.deepdive.alphabet.title': string;
+  'tools.base64.deepdive.alphabet.intro': string;
+  'tools.base64.deepdive.uses.title': string;
+  'tools.base64.deepdive.uses.intro': string;
+  'tools.base64.deepdive.pitfalls.title': string;
+  'tools.base64.deepdive.pitfalls.intro': string;
 
   // Day 2 — base64-basic-auth (HTTP Basic Authorization header builder)
   'tools.basicauth.mode.aria': string;
@@ -101,6 +113,7 @@ export interface Translations {
   'tools.basicauth.copy.password': string;
   'tools.basicauth.paste.header': string;
   'tools.basicauth.invalid': string;
+  'tools.basicauth.heading': string;
   'tools.basicauth.intro': string;
 
   // Topbar language switcher — overrides browser default for the session;

--- a/src/style.css
+++ b/src/style.css
@@ -304,17 +304,10 @@ select {
   margin: 0 auto;
 }
 
-@media (max-width: 720px) {
-  .dt-app {
-    grid-template-columns: 1fr;
-  }
-  .dt-sidebar {
-    display: none;
-  }
-  .dt-app__content {
-    padding: var(--sp-5) var(--sp-4) var(--sp-8);
-  }
-}
+/* Responsive overrides live in the dedicated section at the bottom of the
+ * file so they always win against the regular component rules below
+ * (CSS source order matters when specificity is equal). Don't add
+ * @media here. */
 
 /* ─── Topbar ─── */
 
@@ -329,6 +322,13 @@ select {
   position: sticky;
   top: 0;
   z-index: 10;
+}
+
+/* Hamburger button — hidden on desktop, shown via the responsive section.
+ * Compound selector keeps specificity higher than `.dt-btn--icon` so the
+ * later button-primitive rule doesn't override this layout default. */
+.dt-topbar__menu.dt-btn {
+  display: none;
 }
 
 .dt-topbar__left,
@@ -969,7 +969,7 @@ select {
 .dt-base64__switch-input {
   /* Visually hidden but still in the layout flow at the label's origin so
      keyboard focus and Playwright's .check() can find and activate it.
-     pointer-events stays default — removing it would break the click
+     pointer-events stays default — removing it would break click
      forwarding from <label> to the underlying checkbox. */
   position: absolute;
   opacity: 0;
@@ -1091,10 +1091,10 @@ select {
 }
 
 .dt-base64__copy {
-  /* axe "large text" threshold (3:1) is 14pt = 18.66px bold or 18pt = 24px
-     regular. 20px @ 700 clears 14pt bold so accent/accent-fg passes on
-     Linear (3.95:1) and Vercel (3.34:1) themes — matches the precedent set
-     by the brand-mark fix. */
+  /* axe "large text" threshold (3:1 ratio) is 14pt = 18.66px bold or 18pt
+     = 24px regular. 20px @ 700 clears 14pt bold so accent/accent-fg
+     passes on Linear (3.95:1) and Vercel (3.34:1) themes — matches the
+     precedent set by the brand-mark a11y bump. */
   font-size: 20px;
   font-weight: 700;
   padding: var(--sp-2) var(--sp-5);
@@ -1128,9 +1128,7 @@ select {
 /* ─── Paste button on the input pane (subtler than the primary copy CTA) ─── */
 .dt-base64__paste {
   /* Match the copy button's 20px@700 so the two pills line up visually.
-     Background uses surface tones rather than accent — paste is a secondary
-     action, so it stays understated next to the primary copy CTA. The
-     surface/fg-strong combo always passes contrast in every theme. */
+     Surface tones (not accent) keep the secondary action understated. */
   font-size: 20px;
   font-weight: 700;
   padding: var(--sp-2) var(--sp-5);
@@ -1202,19 +1200,8 @@ select {
   outline-offset: 2px;
 }
 
-/* ─── Mobile / tablet stack ─── */
-@media (max-width: 880px) {
-  .dt-base64__workspace {
-    grid-template-columns: 1fr;
-  }
-  .dt-base64__swap {
-    justify-self: center;
-    transform: rotate(90deg);
-  }
-  .dt-base64__swap:hover {
-    transform: rotate(270deg);
-  }
-}
+/* Mobile/tablet workspace stack is consolidated in the responsive section
+ * at the bottom of the file. */
 
 /* ─── Explainer / "how it works" block beneath the workspace ─── */
 .dt-base64__explainer {
@@ -1296,9 +1283,8 @@ select {
   background: var(--accent);
   color: var(--accent-fg);
   border-radius: var(--radius-pill);
-  /* 20px @ 700 clears the 14pt-bold large-text threshold so accent/accent-fg
-     passes the 3:1 ratio on Linear and Vercel themes (where the raw
-     accent/accent-fg combo sits at 3.95 and 3.34 respectively). */
+  /* 20px@700 clears axe's 14pt-bold large-text threshold so accent/accent-fg
+     passes 3:1 on Linear (3.95:1) and Vercel (3.34:1). */
   font-weight: 700;
   font-size: 20px;
   transition:
@@ -1315,6 +1301,116 @@ select {
   transform: scale(0.98);
 }
 
+/* ─── Expandable deep-dive blocks (<details>/<summary>) ─── */
+
+.dt-base64__deepdive {
+  margin-top: var(--sp-3);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-2);
+  overflow: hidden;
+}
+
+.dt-base64__deepdive[open] {
+  background: var(--bg-surface);
+  border-color: var(--line-strong);
+  box-shadow: var(--shadow-1);
+}
+
+.dt-base64__deepdive-summary {
+  font-family: var(--font-head);
+  font-size: var(--fs-base);
+  font-weight: 600;
+  color: var(--fg-strong);
+  padding: var(--sp-3) var(--sp-4);
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  user-select: none;
+}
+
+/* Hide the default disclosure triangle in WebKit. */
+.dt-base64__deepdive-summary::-webkit-details-marker {
+  display: none;
+}
+
+/* Custom chevron that rotates on open. */
+.dt-base64__deepdive-summary::before {
+  content: '▸';
+  display: inline-block;
+  font-size: 12px;
+  color: var(--fg-muted);
+  transition: transform var(--anim-fast);
+  width: 1em;
+}
+
+.dt-base64__deepdive[open] > .dt-base64__deepdive-summary::before {
+  transform: rotate(90deg);
+  color: var(--accent);
+}
+
+.dt-base64__deepdive-summary:hover {
+  background: var(--bg-surface-hover);
+}
+
+.dt-base64__deepdive-summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* Body padding inside details. The first child after summary gets the
+ * generous gap; pre/list elements space themselves. */
+.dt-base64__deepdive > *:not(summary) {
+  margin-left: var(--sp-4);
+  margin-right: var(--sp-4);
+}
+
+.dt-base64__deepdive > *:nth-child(2) {
+  margin-top: 0;
+}
+
+.dt-base64__deepdive > *:last-child {
+  margin-bottom: var(--sp-4);
+}
+
+.dt-base64__deepdive .dt-base64__explainer-p {
+  margin: 0 var(--sp-4) var(--sp-3);
+  color: var(--fg-default);
+  line-height: var(--lh-base);
+}
+
+.dt-base64__deepdive .dt-base64__explainer-eg {
+  margin: 0 var(--sp-4) var(--sp-3);
+  font-size: var(--fs-xs);
+  line-height: 1.55;
+}
+
+.dt-base64__deepdive-list {
+  margin: 0 var(--sp-4) var(--sp-4);
+  padding-left: var(--sp-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  color: var(--fg-default);
+  line-height: var(--lh-base);
+}
+
+.dt-base64__deepdive-list strong {
+  color: var(--fg-strong);
+}
+
+.dt-base64__deepdive-list code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  padding: 0 4px;
+  background: var(--bg-surface-2);
+  border: var(--border-w) solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--fg-strong);
+}
+
 /* ─── Day 2: base64-basic-auth ─── */
 
 .dt-basicauth {
@@ -1329,15 +1425,6 @@ select {
   display: flex;
   flex-direction: column;
   gap: var(--sp-3);
-}
-
-.dt-basicauth__heading {
-  margin: 0;
-  font-family: var(--font-head);
-  font-size: var(--fs-xl);
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--fg-strong);
 }
 
 .dt-basicauth__intro {
@@ -1445,8 +1532,264 @@ select {
   color: var(--accent);
 }
 
+/* ─── Mobile drawer & backdrop ───────────────────────────────────────────
+ * Desktop: sidebar is sticky, drawer/backdrop are inert.
+ * Mobile: sidebar slides in from the left with a translucent backdrop. */
+
+.dt-sidebar__close {
+  display: none;
+  position: absolute;
+  top: var(--sp-3);
+  right: var(--sp-3);
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: var(--border-w) solid var(--line);
+  background: var(--bg-surface);
+  color: var(--fg-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.dt-sidebar__close:hover {
+  background: var(--bg-surface-hover);
+  color: var(--fg-strong);
+}
+
+.dt-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 19;
+  opacity: 0;
+  transition: opacity var(--anim-fast);
+}
+
+/* ─── Responsive overrides ───────────────────────────────────────────────
+ * Single consolidated block placed at the very end of the file so it
+ * always wins over the regular component rules above. Two breakpoints:
+ *   - <=880px: stack the dual-pane workspaces.
+ *   - <=720px: collapse sidebar into a drawer, compact topbar, tighten
+ *              paddings, ensure touch targets. */
+
 @media (max-width: 880px) {
+  .dt-base64__workspace {
+    grid-template-columns: 1fr;
+  }
+  .dt-base64__swap {
+    justify-self: center;
+    transform: rotate(90deg);
+  }
+  .dt-base64__swap:hover {
+    transform: rotate(270deg);
+  }
   .dt-basicauth__workspace {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  /* Layout shell: single column with the sidebar overlaid as a drawer. */
+  .dt-app {
+    grid-template-columns: 1fr;
+  }
+
+  /* Hamburger button visible in the topbar — compound selector mirrors
+     the desktop hide rule's specificity. */
+  .dt-topbar__menu.dt-btn {
+    display: inline-flex;
+  }
+
+  /* Compact topbar: tighten padding, hide secondary affordances we can
+     reach from the drawer or skip on phones. The breadcrumb prefix is
+     too long on mobile; fade older crumbs and emphasize the active one. */
+  .dt-topbar {
+    padding: 0 var(--sp-3);
+    gap: var(--sp-2);
+  }
+  .dt-topbar__left {
+    flex: 1;
+    min-width: 0;
+  }
+  .dt-crumb {
+    font-size: var(--fs-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+  .dt-topbar__gh {
+    display: none; /* repo link is one tap away from the GitHub icon in the footer */
+  }
+
+  /* Sidebar becomes a left-side drawer. Display:flex on a position-fixed
+     overlay; transform off-canvas by default; slide in when host has
+     data-drawer="open". */
+  .dt-sidebar {
+    display: flex;
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(86vw, 320px);
+    height: 100vh;
+    z-index: 20;
+    box-shadow: var(--shadow-3);
+    transform: translateX(-100%);
+    transition: transform var(--anim-base);
+    padding-top: var(--sp-6);
+  }
+  .dt-app[data-drawer='open'] .dt-sidebar {
+    transform: translateX(0);
+  }
+  .dt-sidebar__close {
+    display: inline-flex;
+  }
+
+  /* Backdrop fades in/out with the drawer. */
+  .dt-app[data-drawer='open'] .dt-backdrop {
+    display: block;
+    opacity: 1;
+  }
+  .dt-app[data-drawer='open'] {
+    overflow: hidden;
+  }
+
+  /* RTL flip for Arabic — drawer comes from the right. */
+  html[dir='rtl'] .dt-sidebar {
+    inset: 0 0 0 auto;
+    transform: translateX(100%);
+  }
+  html[dir='rtl'] .dt-app[data-drawer='open'] .dt-sidebar {
+    transform: translateX(0);
+  }
+  html[dir='rtl'] .dt-sidebar__close {
+    right: auto;
+    left: var(--sp-3);
+  }
+
+  /* Tighten content paddings on phones. */
+  .dt-app__content {
+    padding: var(--sp-4) var(--sp-3) var(--sp-6);
+  }
+
+  /* Tool views — compact paddings and tighten the top control bar so the
+     mode tabs + URL-safe toggle stack instead of overflowing. */
+  .dt-base64,
+  .dt-basicauth {
+    padding: var(--sp-3) 0;
+    gap: var(--sp-3);
+  }
+  .dt-base64__controls,
+  .dt-basicauth__top {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--sp-3);
+  }
+  .dt-base64__segmented {
+    align-self: stretch;
+  }
+  .dt-base64__tab {
+    flex: 1;
+    min-width: 0;
+  }
+  .dt-base64__pane {
+    padding: var(--sp-3);
+  }
+  .dt-base64__textarea {
+    min-height: 180px;
+    font-size: var(--fs-sm);
+  }
+  .dt-base64__pane-foot {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--sp-2);
+  }
+  /* Buttons full-width on mobile so they're easy to tap. */
+  .dt-base64__copy,
+  .dt-base64__paste {
+    justify-content: center;
+    width: 100%;
+    font-size: var(--fs-base);
+    padding: var(--sp-3) var(--sp-4);
+  }
+  .dt-base64__lengths {
+    text-align: center;
+  }
+
+  /* Explainer: tighten padding, allow wider prose, code block scrolls. */
+  .dt-base64__explainer {
+    padding: var(--sp-4);
+    margin-top: var(--sp-5);
+  }
+  .dt-base64__explainer-h {
+    font-size: var(--fs-lg);
+  }
+  .dt-base64__explainer-eg {
+    font-size: var(--fs-xs);
+    padding: var(--sp-2) var(--sp-3);
+  }
+  .dt-base64__explainer-cta {
+    align-self: stretch;
+    text-align: center;
+    font-size: var(--fs-base);
+  }
+
+  /* Basic-auth tool — pane padding + per-field copy buttons stay readable. */
+  .dt-basicauth__pane {
+    padding: var(--sp-3);
+  }
+  .dt-basicauth__field-row {
+    flex-wrap: wrap;
+  }
+  .dt-basicauth__field-row > input {
+    width: 100%;
+    flex-basis: 100%;
+  }
+  .dt-basicauth__suffixwrap {
+    width: 100%;
+    justify-content: flex-end;
+  }
+  .dt-basicauth__field-copy {
+    min-height: 36px;
+  }
+  .dt-basicauth__foot-actions {
+    width: 100%;
+    flex-direction: column;
+    gap: var(--sp-2);
+  }
+  .dt-basicauth__foot-actions > * {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* Home grid — single column on phones. */
+  .dt-home__grid {
+    grid-template-columns: 1fr;
+  }
+  .dt-home__hero h1 {
+    font-size: 24px;
+  }
+
+  /* Footer — wrap onto multiple lines instead of trying to fit one row. */
+  .dt-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--sp-3);
+    padding: var(--sp-5) var(--sp-4);
+  }
+  .dt-footer__links {
+    flex-wrap: wrap;
+    gap: var(--sp-3);
+  }
+
+  /* Theme switcher trigger collapses to icon only on phones. */
+  .dt-theme-switcher span:first-of-type {
+    display: none;
+  }
+  .dt-language-switcher__code {
+    display: none;
   }
 }

--- a/src/tools/01-encoding/001-base64-string-converter/render.ts
+++ b/src/tools/01-encoding/001-base64-string-converter/render.ts
@@ -46,9 +46,9 @@ export function render(
   toggleInput.classList.add('dt-base64__switch-input');
   toggleInput.checked = state.urlsafe;
   // No explicit aria-label — the wrapping <label> provides the accessible
-  // name from the visible text, so screen-reader and visual users hear the
-  // same thing. Setting aria-label here would override the visible text and
-  // also break Playwright's getByLabel(/URL-safe variant/i) lookup.
+  // name from the visible text. Setting aria-label here would override the
+  // visible text for screen readers AND make Playwright's
+  // getByLabel(/URL-safe variant/i) miss the checkbox.
   const toggleVisual = doc.createElement('span');
   toggleVisual.classList.add('dt-base64__switch-visual');
   toggleVisual.setAttribute('aria-hidden', 'true');
@@ -289,16 +289,16 @@ function placeholderFor(mode: Mode): string {
     : translate('tools.base64.placeholder.decode');
 }
 
-/** Builds the explainer block — heading, prose paragraphs, a worked example
- *  table, and a deep link to the Basic Auth helper. The example bytes/bits
- *  are universal and stay in code (not i18n) so they render the same in
- *  every locale. */
+/** Builds the explainer block — heading, summary prose, the "Cat" worked
+ *  example, common-uses pointer, warning, plus four expandable deep-dive
+ *  sections (encoding mechanic, alphabet, real-world uses, pitfalls). The
+ *  numeric / table content stays in code (universal across locales);
+ *  prose lines come from i18n. */
 function buildExplainer(doc: Document): HTMLElement {
   const section = doc.createElement('section');
   section.classList.add('dt-base64__explainer');
 
-  // Use h1 — the tool view doesn't otherwise have a level-one heading, so
-  // axe's page-has-heading-one best-practice rule fails without it.
+  // h1 — page-level heading; satisfies axe page-has-heading-one too.
   const heading = doc.createElement('h1');
   heading.classList.add('dt-base64__explainer-h');
   heading.textContent = translate('tools.base64.explainer.heading');
@@ -332,6 +332,15 @@ function buildExplainer(doc: Document): HTMLElement {
   warn.textContent = translate('tools.base64.explainer.warning');
   section.appendChild(warn);
 
+  // ─── Deep-dive expandables ─────────────────────────────────────────────
+  // Use <details>/<summary> for native, accessible expand/collapse without
+  // JS state. Each section opens to a longer technical explanation with
+  // code blocks, padding rules, and pitfalls.
+  section.appendChild(buildEncodingDeepDive(doc));
+  section.appendChild(buildAlphabetDeepDive(doc));
+  section.appendChild(buildUsesDeepDive(doc));
+  section.appendChild(buildPitfallsDeepDive(doc));
+
   const tryAuth = doc.createElement('a');
   tryAuth.classList.add('dt-base64__explainer-cta');
   tryAuth.href = '#/base64-basic-auth';
@@ -358,4 +367,212 @@ function makeP(doc: Document, text: string): HTMLParagraphElement {
     }
   }
   return p;
+}
+
+function makeDetails(doc: Document, summaryText: string): HTMLDetailsElement {
+  const details = doc.createElement('details');
+  details.classList.add('dt-base64__deepdive');
+  const summary = doc.createElement('summary');
+  summary.classList.add('dt-base64__deepdive-summary');
+  summary.textContent = summaryText;
+  details.appendChild(summary);
+  return details;
+}
+
+function makePre(doc: Document, lines: readonly string[], ariaLabel?: string): HTMLPreElement {
+  const pre = doc.createElement('pre');
+  pre.classList.add('dt-base64__explainer-eg');
+  if (ariaLabel) pre.setAttribute('aria-label', ariaLabel);
+  pre.textContent = lines.join('\n');
+  return pre;
+}
+
+/** Step-by-step encoding deep-dive: full 24-bit chunk + the two padding cases. */
+function buildEncodingDeepDive(doc: Document): HTMLDetailsElement {
+  const details = makeDetails(doc, translate('tools.base64.deepdive.encoding.title'));
+  details.appendChild(makeP(doc, translate('tools.base64.deepdive.encoding.intro')));
+
+  // Full 3-byte chunk: "Man" → "TWFu" (no padding case).
+  details.appendChild(
+    makePre(
+      doc,
+      [
+        'Encode "Man"  (3 bytes → 4 chars, no padding)',
+        '',
+        'ASCII   M         a         n',
+        'hex     0x4D      0x61      0x6E',
+        'bytes   01001101  01100001  01101110',
+        'regroup 010011 010110 000101 101110',
+        'index   19     22     5      46',
+        'output  T      W      F      u',
+      ],
+      'Encoding "Man" to TWFu — three bytes producing four base64 characters',
+    ),
+  );
+
+  // 2-byte case: "Ma" → "TWE=" (one pad).
+  details.appendChild(
+    makePre(
+      doc,
+      [
+        'Encode "Ma"  (2 bytes → 3 chars + "=" pad)',
+        '',
+        'ASCII   M         a',
+        'bytes   01001101  01100001',
+        'regroup 010011 010110 000100',  // last group right-padded with zero bits
+        'index   19     22     4      —',
+        'output  T      W      E      =',
+      ],
+      'Encoding "Ma" to TWE= — two bytes plus one padding character',
+    ),
+  );
+
+  // 1-byte case: "M" → "TQ==" (two pads).
+  details.appendChild(
+    makePre(
+      doc,
+      [
+        'Encode "M"   (1 byte → 2 chars + "==" pad)',
+        '',
+        'ASCII   M',
+        'bytes   01001101',
+        'regroup 010011 010000',  // 4 trailing bits zero-padded
+        'index   19     16     —      —',
+        'output  T      Q      =      =',
+      ],
+      'Encoding "M" to TQ== — one byte plus two padding characters',
+    ),
+  );
+
+  details.appendChild(
+    makeP(
+      doc,
+      'Padding rule: the output length is always a multiple of 4. Each `=` says "the previous character carried zero-padded bits, ignore them on decode."',
+    ),
+  );
+
+  return details;
+}
+
+/** Alphabet deep-dive: the 64 characters in order, plus the URL-safe diff. */
+function buildAlphabetDeepDive(doc: Document): HTMLDetailsElement {
+  const details = makeDetails(doc, translate('tools.base64.deepdive.alphabet.title'));
+  details.appendChild(makeP(doc, translate('tools.base64.deepdive.alphabet.intro')));
+
+  details.appendChild(
+    makePre(
+      doc,
+      [
+        'index  char    index  char    index  char    index  char',
+        '----------------------------------------------------------',
+        '  0    A         16   Q         32   g         48   w',
+        '  1    B         17   R         33   h         49   x',
+        '  2    C         18   S         34   i         50   y',
+        '  3    D         19   T         35   j         51   z',
+        '  4    E         20   U         36   k         52   0',
+        '  5    F         21   V         37   l         53   1',
+        '  6    G         22   W         38   m         54   2',
+        '  7    H         23   X         39   n         55   3',
+        '  8    I         24   Y         40   o         56   4',
+        '  9    J         25   Z         41   p         57   5',
+        ' 10    K         26   a         42   q         58   6',
+        ' 11    L         27   b         43   r         59   7',
+        ' 12    M         28   c         44   s         60   8',
+        ' 13    N         29   d         45   t         61   9',
+        ' 14    O         30   e         46   u         62   +    (URL-safe: -)',
+        ' 15    P         31   f         47   v         63   /    (URL-safe: _)',
+        '',
+        '"=" is reserved for padding; URL-safe variant strips it.',
+      ],
+      'Base64 alphabet: 64 characters indexed 0-63 plus the URL-safe substitutions',
+    ),
+  );
+
+  return details;
+}
+
+/** Common-uses deep-dive: HTTP, JWT, data URIs, MIME. */
+function buildUsesDeepDive(doc: Document): HTMLDetailsElement {
+  const details = makeDetails(doc, translate('tools.base64.deepdive.uses.title'));
+  details.appendChild(makeP(doc, translate('tools.base64.deepdive.uses.intro')));
+
+  details.appendChild(
+    makePre(
+      doc,
+      [
+        '# 1. HTTP Basic Auth (RFC 7617)',
+        '   Authorization: Basic YWxhZGRpbjpvcGVuIHNlc2FtZQ==',
+        '   decoded → "aladdin:open sesame"',
+        '',
+        '# 2. JWT segments (RFC 7519, base64url)',
+        '   eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.SflKxw...',
+        '   header    .  payload                   .  signature',
+        '',
+        '# 3. data: URIs (RFC 2397)',
+        '   <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAA...">',
+        '',
+        '# 4. Email MIME (RFC 2045 §6.8)',
+        '   Content-Transfer-Encoding: base64',
+        '   ...wraps lines at 76 characters...',
+      ],
+      'Common base64 use cases: HTTP Basic Auth, JWT, data URIs, MIME email',
+    ),
+  );
+
+  return details;
+}
+
+/** Pitfalls deep-dive — the things that bite. */
+function buildPitfallsDeepDive(doc: Document): HTMLDetailsElement {
+  const details = makeDetails(doc, translate('tools.base64.deepdive.pitfalls.title'));
+  details.appendChild(makeP(doc, translate('tools.base64.deepdive.pitfalls.intro')));
+
+  const list = doc.createElement('ul');
+  list.classList.add('dt-base64__deepdive-list');
+  const items: readonly (readonly [string, string])[] = [
+    [
+      'Standard vs URL-safe',
+      'Pick one and stick with it. Decoding URL-safe input with a strict standard decoder fails; the safe alphabet uses `-` and `_` instead of `+` and `/`, and usually omits `=` padding.',
+    ],
+    [
+      'UTF-8 ≠ Latin-1',
+      "`btoa('日本語')` throws — `btoa` only handles single-byte characters. Always encode through `TextEncoder` first so multibyte UTF-8 round-trips. This tool does that automatically.",
+    ],
+    [
+      'Padding on decode',
+      'Some decoders require `=` padding to a multiple of 4; some accept missing padding; some reject extra padding. When you control both ends, prefer URL-safe + no padding.',
+    ],
+    [
+      'Line wrapping',
+      'MIME wraps base64 at 76 characters with `\\r\\n`. JSON-embedded base64 generally does not. Strip whitespace before decoding if your decoder is strict.',
+    ],
+    [
+      'Not encryption',
+      "If you can read the string, you can read the data. Anyone capturing a `Basic` header can pull out the password. Use it for transport, not for secrecy.",
+    ],
+  ];
+
+  for (const [term, body] of items) {
+    const li = doc.createElement('li');
+    const strong = doc.createElement('strong');
+    strong.textContent = term;
+    li.appendChild(strong);
+    li.appendChild(doc.createTextNode(' — '));
+    // Inline-code support inside the body text.
+    const parts = body.split('`');
+    for (let i = 0; i < parts.length; i += 1) {
+      const part = parts[i];
+      if (part === undefined) continue;
+      if (i % 2 === 0) {
+        li.appendChild(doc.createTextNode(part));
+      } else {
+        const code = doc.createElement('code');
+        code.textContent = part;
+        li.appendChild(code);
+      }
+    }
+    list.appendChild(li);
+  }
+  details.appendChild(list);
+  return details;
 }

--- a/src/tools/01-encoding/002-base64-basic-auth/render.ts
+++ b/src/tools/01-encoding/002-base64-basic-auth/render.ts
@@ -36,10 +36,10 @@ export function render(
   top.appendChild(tabs);
 
   // h1 placed above the intro so the tool view satisfies axe's
-  // page-has-heading-one best-practice rule. Visually styled compact.
+  // page-has-heading-one best-practice rule. Visually compact.
   const heading = doc.createElement('h1');
   heading.classList.add('dt-basicauth__heading');
-  heading.textContent = translate('tools.basicauth.header.label');
+  heading.textContent = translate('tools.basicauth.heading');
   top.appendChild(heading);
 
   const intro = doc.createElement('p');

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -23,19 +23,41 @@ export interface LayoutOptions {
 export function layout(opts: LayoutOptions): LayoutHandle {
   opts.host.replaceChildren();
   opts.host.classList.add('dt-app');
+  // Drawer state lives on the host as a data attribute so CSS can style
+  // both the sidebar and a sibling backdrop without JS-side bookkeeping.
+  opts.host.dataset.drawer = 'closed';
+
+  // Backdrop sits visually between the sidebar (overlay) and the content.
+  // Hidden on desktop via CSS; toggled visible with the drawer.
+  const backdrop = document.createElement('div');
+  backdrop.classList.add('dt-backdrop');
+  backdrop.addEventListener('click', closeDrawer);
 
   const sb = sidebar({
     tools: opts.tools,
-    onSelect: (id) => opts.onSelectTool?.(id),
+    onSelect: (id) => {
+      // Selecting a tool from the drawer should close it on mobile.
+      closeDrawer();
+      opts.onSelectTool?.(id);
+    },
   });
+
+  // Close button inside the drawer for mobile users — invisible on desktop.
+  const drawerClose = document.createElement('button');
+  drawerClose.type = 'button';
+  drawerClose.classList.add('dt-sidebar__close');
+  drawerClose.setAttribute('aria-label', 'Close menu');
+  drawerClose.innerHTML = '<span aria-hidden="true">×</span>';
+  drawerClose.addEventListener('click', closeDrawer);
+  sb.el.prepend(drawerClose);
 
   const main = document.createElement('div');
   main.classList.add('dt-app__main');
 
   const tb = topbar(
     opts.repoUrl !== undefined
-      ? { initialTheme: opts.initialTheme, repoUrl: opts.repoUrl }
-      : { initialTheme: opts.initialTheme },
+      ? { initialTheme: opts.initialTheme, repoUrl: opts.repoUrl, onMenuClick: openDrawer }
+      : { initialTheme: opts.initialTheme, onMenuClick: openDrawer },
   );
 
   const content = document.createElement('main');
@@ -43,7 +65,23 @@ export function layout(opts: LayoutOptions): LayoutHandle {
 
   const ft = footer();
   main.append(tb.el, content, ft.el);
-  opts.host.append(sb.el, main);
+  opts.host.append(sb.el, backdrop, main);
+
+  // Esc key closes the drawer.
+  const onKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && opts.host.dataset.drawer === 'open') {
+      closeDrawer();
+    }
+  };
+  document.addEventListener('keydown', onKeydown);
+
+  function openDrawer(): void {
+    opts.host.dataset.drawer = 'open';
+  }
+
+  function closeDrawer(): void {
+    opts.host.dataset.drawer = 'closed';
+  }
 
   function setView(node: HTMLElement, crumb: readonly string[]): void {
     content.replaceChildren(node);
@@ -56,6 +94,7 @@ export function layout(opts: LayoutOptions): LayoutHandle {
     content,
     setView,
     dispose() {
+      document.removeEventListener('keydown', onKeydown);
       tb.dispose();
       sb.dispose();
     },

--- a/src/ui/primitives/icon.ts
+++ b/src/ui/primitives/icon.ts
@@ -15,6 +15,7 @@ const ICONS = {
   github: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.4 5.4 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>`,
   star: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z"/></svg>`,
   arrowRight: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>`,
+  menu: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/></svg>`,
 } as const;
 
 export type IconName = keyof typeof ICONS;

--- a/src/ui/topbar/index.ts
+++ b/src/ui/topbar/index.ts
@@ -1,6 +1,6 @@
 import { translate, getLocale } from '../../lib/i18n';
 import type { Theme } from '../../lib/theme';
-import { button, icon } from '../primitives';
+import { button } from '../primitives';
 import { languageSwitcher } from './language-switcher';
 import { themeSwitcher } from './theme-switcher';
 
@@ -14,6 +14,8 @@ export interface TopbarOptions {
   initialTheme: Theme;
   initialCrumb?: readonly string[];
   repoUrl?: string;
+  /** Fired when the hamburger menu button is clicked (mobile drawer open). */
+  onMenuClick?: () => void;
 }
 
 export function topbar(opts: TopbarOptions): TopbarHandle {
@@ -22,6 +24,23 @@ export function topbar(opts: TopbarOptions): TopbarHandle {
 
   const left = document.createElement('div');
   left.classList.add('dt-topbar__left');
+
+  // Hamburger — only visible on mobile via CSS. Wired to a layout-level
+  // callback so the sidebar can be opened as a drawer.
+  const menuBtn = button({
+    iconName: 'menu',
+    variant: 'icon',
+    ariaLabel: translate('topbar.menu.aria'),
+  });
+  menuBtn.classList.add('dt-topbar__menu');
+  if (opts.onMenuClick) {
+    const handler = opts.onMenuClick;
+    menuBtn.addEventListener('click', () => {
+      handler();
+    });
+  }
+  left.appendChild(menuBtn);
+
   const crumb = document.createElement('div');
   crumb.classList.add('dt-crumb');
   left.appendChild(crumb);
@@ -43,6 +62,7 @@ export function topbar(opts: TopbarOptions): TopbarHandle {
     ghLink.href = opts.repoUrl;
     ghLink.target = '_blank';
     ghLink.rel = 'noreferrer noopener';
+    ghLink.classList.add('dt-topbar__gh');
     const ghBtn = button({
       iconName: 'github',
       variant: 'icon',
@@ -71,8 +91,6 @@ export function topbar(opts: TopbarOptions): TopbarHandle {
   }
 
   setCrumb(opts.initialCrumb ?? ['Home']);
-  // Suppress unused-icon-import lint by exposing a helper for future use.
-  void icon;
 
   return {
     el,


### PR DESCRIPTION
## Summary

The site was unusable below 720 px — the sidebar covered the whole viewport, the topbar overflowed, and the dual-pane workspaces wouldn't stack. This PR fixes the mobile layout end-to-end and adds expandable deep-dive sections to the base64 explainer for the technical-detail-on-click experience the user asked for.

### Mobile UX

- **Hamburger menu** in the topbar opens the sidebar as a slide-in drawer with a translucent backdrop. Dismissible via tap-out, Esc key, or close button. Selecting a tool auto-closes the drawer.
- **Root-cause CSS fix.** The previous `@media (max-width: 720px) { .dt-sidebar { display: none } }` lived BEFORE the regular `.dt-sidebar { display: flex }` rule, so the later rule won source order and the sidebar was never hidden. All responsive @media now lives in a single block at the bottom of `style.css`.
- **Two breakpoints**: `≤880 px` stacks the two-pane workspaces; `≤720 px` collapses the sidebar into the drawer, tightens topbar padding, hides the GitHub icon (footer has it), shrinks the language switcher to flag-only, collapses the theme switcher to icon-only, makes copy/paste pills full-width, wraps the footer, and switches the tool grid to a single column.
- **RTL mirror** for Arabic — drawer slides from the right, close button moves to the left edge.

### Base64 explainer — expandable deep-dives

Native `<details>`/`<summary>` blocks, zero JS state, accessible by default, custom rotating chevron. Four sections under the existing summary:

1. **Step-by-step encoding** for `Man → TWFu` plus the two padding cases (`Ma → TWE=`, `M → TQ==`).
2. **The 64-character alphabet** — full table with URL-safe substitutions called out.
3. **Real-world places** — HTTP Basic Auth, JWT, data: URIs, MIME.
4. **Pitfalls** — Standard vs URL-safe, UTF-8 vs Latin-1, padding, line wrapping, "not encryption."

### a11y / e2e

- `<h1>` restored on both tool views (was lost in a prior revert) so axe's `page-has-heading-one` best-practice rule passes.
- Hamburger button uses compound `.dt-topbar__menu.dt-btn` so it beats `.dt-btn--icon`'s `display: grid`.

### i18n

- New keys: `topbar.menu.aria`, `tools.basicauth.heading`, plus 8 `tools.base64.deepdive.{encoding,alphabet,uses,pitfalls}.{title,intro}` keys.
- All translated across the 15 supported locales.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (15 pre-existing warnings on scripts/sync-translations.ts only)
- [x] `pnpm test` — 140/140 unit tests passing
- [x] `pnpm exec playwright test --project=chromium` — 24/24 passing
- [x] Manual mobile (375 px) verification: drawer opens, backdrop dismisses, tool views stack, copy/paste full-width
- [x] Manual desktop (1280 px) verification: hamburger hidden, sidebar sticky, workspace side-by-side
- [x] All seven themes verified through axe — no contrast regressions