### PR TITLE
feat(html-entities): Day 3 — encoder/decoder for SGML-five + extended Latin-1 set

### DIFF
--- a/scripts/translations-data.ts
+++ b/scripts/translations-data.ts
@@ -122,6 +122,34 @@ const es: Translations = {
   'tools.basicauth.heading': 'Asistente de HTTP Basic Auth',
   'tools.basicauth.intro':
     'Construye y lee la cabecera `Authorization: Basic <base64>` que usa la autenticación HTTP Basic. Todo en local — las credenciales nunca salen de tu navegador.',
+  'tools.entities.heading': 'Entidades HTML — codificador / decodificador',
+  'tools.entities.intro':
+    'Codifica `&`, `<`, `>`, `"`, `\'` para incrustación HTML segura, o extiende al conjunto Latin-1 + monedas + matemáticas + comillas tipográficas. Decodifica cualquier entidad nombrada o numérica.',
+  'tools.entities.mode.aria': 'Codificar o decodificar',
+  'tools.entities.mode.encode': 'Codificar',
+  'tools.entities.mode.decode': 'Decodificar',
+  'tools.entities.variant.label': 'Conjunto extendido (Latin-1 + monedas + matemáticas)',
+  'tools.entities.variant.aria': 'Cambiar conjunto extendido',
+  'tools.entities.variant.minimal': 'Mínimo',
+  'tools.entities.variant.extended': 'Extendido',
+  'tools.entities.label.text': 'Texto',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Entrada de la herramienta de entidades HTML',
+  'tools.entities.result.aria': 'Salida de la herramienta de entidades HTML',
+  'tools.entities.placeholder.encode':
+    'Escribe o pega — emoji y acentos sobreviven. Activa extendido para monedas / comillas tipográficas.',
+  'tools.entities.placeholder.decode':
+    'Pega HTML — `&copy;`, `&#65;`, `&#x41;` se decodifican. Las entidades desconocidas pasan intactas.',
+  'tools.entities.entities.found': '{n} entidades decodificadas',
+  'tools.entities.explainer.minimal.heading': 'Mínimo: las cinco SGML',
+  'tools.entities.explainer.minimal.body':
+    'Solo `&`, `<`, `>`, `"`, `\'` se escapan. Idempotente al re-decodificar y la opción correcta para escapar input de usuario al incrustar HTML.',
+  'tools.entities.explainer.extended.heading': 'Extendido: Latin-1 + comillas + matemáticas',
+  'tools.entities.explainer.extended.body':
+    'Añade `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, `“ ”`, `‘ ’`, operadores matemáticos, flechas. Útil cuando quieres HTML 100 % ASCII después de un pegado / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numérico: decimal y hexadecimal',
+  'tools.entities.explainer.numeric.body':
+    'Decodifica tanto `&#65;` (decimal) como `&#x41;` / `&#X41;` (hex), incluyendo codepoints astrales — `&#128512;` y `&#x1F600;` ambos van a 😀.',
 };
 
 const fr: Translations = {
@@ -232,6 +260,34 @@ const fr: Translations = {
   'tools.basicauth.heading': 'Aide HTTP Basic Auth',
   'tools.basicauth.intro':
     'Construit et lit l’en-tête `Authorization: Basic <base64>` utilisé par l’authentification HTTP Basic. Tout en local — les identifiants ne quittent jamais ton navigateur.',
+  'tools.entities.heading': 'Entités HTML — encodeur / décodeur',
+  'tools.entities.intro':
+    'Encode `&`, `<`, `>`, `"`, `\'` pour une intégration HTML sûre, ou étend au jeu Latin-1 + devises + math + guillemets typographiques. Décode toute entité nommée ou numérique.',
+  'tools.entities.mode.aria': 'Encoder ou décoder',
+  'tools.entities.mode.encode': 'Encoder',
+  'tools.entities.mode.decode': 'Décoder',
+  'tools.entities.variant.label': 'Jeu étendu (Latin-1 + devises + math)',
+  'tools.entities.variant.aria': 'Activer le jeu étendu',
+  'tools.entities.variant.minimal': 'Minimal',
+  'tools.entities.variant.extended': 'Étendu',
+  'tools.entities.label.text': 'Texte',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Entrée de l’outil entités HTML',
+  'tools.entities.result.aria': 'Sortie de l’outil entités HTML',
+  'tools.entities.placeholder.encode':
+    'Tape ou colle — emoji et accents survivent. Active étendu pour devises / guillemets typographiques.',
+  'tools.entities.placeholder.decode':
+    'Colle du HTML — `&copy;`, `&#65;`, `&#x41;` se décodent. Les entités inconnues passent intactes.',
+  'tools.entities.entities.found': '{n} entités décodées',
+  'tools.entities.explainer.minimal.heading': 'Minimal : les cinq SGML',
+  'tools.entities.explainer.minimal.body':
+    'Seuls `&`, `<`, `>`, `"`, `\'` sont échappés. Idempotent et adapté pour échapper du contenu utilisateur dans du HTML.',
+  'tools.entities.explainer.extended.heading': 'Étendu : Latin-1 + guillemets + math',
+  'tools.entities.explainer.extended.body':
+    'Ajoute `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, guillemets typographiques, opérateurs math, flèches. Utile pour rester en ASCII pur après un coller / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numérique : décimal et hexa',
+  'tools.entities.explainer.numeric.body':
+    'Décode `&#65;` (décimal) comme `&#x41;` / `&#X41;` (hexa), y compris les points de code astraux — `&#128512;` et `&#x1F600;` valent tous deux 😀.',
 };
 
 const de: Translations = {
@@ -342,6 +398,34 @@ const de: Translations = {
   'tools.basicauth.heading': 'HTTP-Basic-Auth-Helfer',
   'tools.basicauth.intro':
     'Baut und liest den Header `Authorization: Basic <base64>`, den HTTP Basic Authentication verwendet. Alles lokal — die Anmeldedaten verlassen den Browser nie.',
+  'tools.entities.heading': 'HTML-Entities — Encoder / Decoder',
+  'tools.entities.intro':
+    'Codiert `&`, `<`, `>`, `"`, `\'` für sicheres HTML-Embedding, oder erweitert auf Latin-1 + Währungen + Mathe + typografische Anführungszeichen. Decodiert jede benannte oder numerische Entity.',
+  'tools.entities.mode.aria': 'Kodieren oder Dekodieren',
+  'tools.entities.mode.encode': 'Kodieren',
+  'tools.entities.mode.decode': 'Dekodieren',
+  'tools.entities.variant.label': 'Erweitertes Set (Latin-1 + Währungen + Mathe)',
+  'tools.entities.variant.aria': 'Erweitertes Set umschalten',
+  'tools.entities.variant.minimal': 'Minimal',
+  'tools.entities.variant.extended': 'Erweitert',
+  'tools.entities.label.text': 'Text',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML-Entities-Tool-Eingabe',
+  'tools.entities.result.aria': 'HTML-Entities-Tool-Ausgabe',
+  'tools.entities.placeholder.encode':
+    'Tippen oder einfügen — Emoji und Akzente überleben. Erweitert für Währungen / typografische Anführungszeichen.',
+  'tools.entities.placeholder.decode':
+    'HTML einfügen — `&copy;`, `&#65;`, `&#x41;` werden dekodiert. Unbekannte Entities bleiben unverändert.',
+  'tools.entities.entities.found': '{n} Entities dekodiert',
+  'tools.entities.explainer.minimal.heading': 'Minimal: die SGML-Fünf',
+  'tools.entities.explainer.minimal.body':
+    'Nur `&`, `<`, `>`, `"`, `\'` werden escapt. Idempotent und richtig zum Escapen von Benutzereingaben für HTML-Embedding.',
+  'tools.entities.explainer.extended.heading': 'Erweitert: Latin-1 + Anführungszeichen + Mathe',
+  'tools.entities.explainer.extended.body':
+    'Fügt `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, typografische Anführungszeichen, Mathe-Operatoren, Pfeile hinzu. Praktisch für reines ASCII nach Paste / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numerisch: dezimal und hexadezimal',
+  'tools.entities.explainer.numeric.body':
+    'Dekodiert sowohl `&#65;` (dezimal) als auch `&#x41;` / `&#X41;` (hex), inklusive astraler Codepoints — `&#128512;` und `&#x1F600;` werden beide zu 😀.',
 };
 
 const pt: Translations = {
@@ -452,6 +536,34 @@ const pt: Translations = {
   'tools.basicauth.heading': 'Ajudante HTTP Basic Auth',
   'tools.basicauth.intro':
     'Constrói e lê o cabeçalho `Authorization: Basic <base64>` usado pela autenticação HTTP Basic. Tudo local — as credenciais nunca saem do seu navegador.',
+  'tools.entities.heading': 'Entidades HTML — codificador / decodificador',
+  'tools.entities.intro':
+    'Codifica `&`, `<`, `>`, `"`, `\'` para incorporação HTML segura, ou estende ao conjunto Latin-1 + moedas + matemática + aspas tipográficas. Decodifica qualquer entidade nomeada ou numérica.',
+  'tools.entities.mode.aria': 'Codificar ou decodificar',
+  'tools.entities.mode.encode': 'Codificar',
+  'tools.entities.mode.decode': 'Decodificar',
+  'tools.entities.variant.label': 'Conjunto estendido (Latin-1 + moedas + matemática)',
+  'tools.entities.variant.aria': 'Alternar conjunto estendido',
+  'tools.entities.variant.minimal': 'Mínimo',
+  'tools.entities.variant.extended': 'Estendido',
+  'tools.entities.label.text': 'Texto',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Entrada da ferramenta de entidades HTML',
+  'tools.entities.result.aria': 'Saída da ferramenta de entidades HTML',
+  'tools.entities.placeholder.encode':
+    'Digite ou cole — emoji e acentos sobrevivem. Ative estendido para moedas / aspas tipográficas.',
+  'tools.entities.placeholder.decode':
+    'Cola HTML — `&copy;`, `&#65;`, `&#x41;` decodificam. Entidades desconhecidas passam intactas.',
+  'tools.entities.entities.found': '{n} entidades decodificadas',
+  'tools.entities.explainer.minimal.heading': 'Mínimo: as cinco SGML',
+  'tools.entities.explainer.minimal.body':
+    'Apenas `&`, `<`, `>`, `"`, `\'` são escapados. Idempotente e a escolha certa para escapar input de usuário em HTML.',
+  'tools.entities.explainer.extended.heading': 'Estendido: Latin-1 + aspas + matemática',
+  'tools.entities.explainer.extended.body':
+    'Adiciona `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, aspas tipográficas, operadores matemáticos, setas. Útil para HTML ASCII puro após colar / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numérico: decimal e hexadecimal',
+  'tools.entities.explainer.numeric.body':
+    'Decodifica tanto `&#65;` (decimal) quanto `&#x41;` / `&#X41;` (hex), incluindo codepoints astrais — `&#128512;` e `&#x1F600;` ambos viram 😀.',
 };
 
 const it: Translations = {
@@ -562,6 +674,34 @@ const it: Translations = {
   'tools.basicauth.heading': 'Aiutante HTTP Basic Auth',
   'tools.basicauth.intro':
     'Costruisce e legge l’header `Authorization: Basic <base64>` usato dall’autenticazione HTTP Basic. Tutto in locale — le credenziali non lasciano mai il tuo browser.',
+  'tools.entities.heading': 'Entità HTML — codificatore / decodificatore',
+  'tools.entities.intro':
+    'Codifica `&`, `<`, `>`, `"`, `\'` per inserimento HTML sicuro, oppure estende a Latin-1 + valute + matematica + virgolette tipografiche. Decodifica qualsiasi entità nominata o numerica.',
+  'tools.entities.mode.aria': 'Codifica o decodifica',
+  'tools.entities.mode.encode': 'Codifica',
+  'tools.entities.mode.decode': 'Decodifica',
+  'tools.entities.variant.label': 'Set esteso (Latin-1 + valute + matematica)',
+  'tools.entities.variant.aria': 'Attiva set esteso',
+  'tools.entities.variant.minimal': 'Minimo',
+  'tools.entities.variant.extended': 'Esteso',
+  'tools.entities.label.text': 'Testo',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Input dello strumento entità HTML',
+  'tools.entities.result.aria': 'Output dello strumento entità HTML',
+  'tools.entities.placeholder.encode':
+    'Scrivi o incolla — emoji e accenti sopravvivono. Attiva esteso per valute / virgolette tipografiche.',
+  'tools.entities.placeholder.decode':
+    'Incolla HTML — `&copy;`, `&#65;`, `&#x41;` si decodificano. Entità sconosciute passano intatte.',
+  'tools.entities.entities.found': '{n} entità decodificate',
+  'tools.entities.explainer.minimal.heading': 'Minimo: le cinque SGML',
+  'tools.entities.explainer.minimal.body':
+    'Solo `&`, `<`, `>`, `"`, `\'` vengono escapate. Idempotente e scelta giusta per escapare input utente da inserire in HTML.',
+  'tools.entities.explainer.extended.heading': 'Esteso: Latin-1 + virgolette + matematica',
+  'tools.entities.explainer.extended.body':
+    'Aggiunge `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, virgolette tipografiche, operatori matematici, frecce. Utile per HTML ASCII puro dopo paste / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numerico: decimale ed esadecimale',
+  'tools.entities.explainer.numeric.body':
+    'Decodifica sia `&#65;` (decimale) sia `&#x41;` / `&#X41;` (hex), inclusi codepoint astrali — `&#128512;` e `&#x1F600;` diventano entrambi 😀.',
 };
 
 const nl: Translations = {
@@ -672,6 +812,34 @@ const nl: Translations = {
   'tools.basicauth.heading': 'HTTP-Basic-Auth-helper',
   'tools.basicauth.intro':
     'Bouwt en leest de `Authorization: Basic <base64>`-header die HTTP Basic Authentication gebruikt. Alles lokaal — gegevens verlaten je browser nooit.',
+  'tools.entities.heading': 'HTML-entiteiten — encoder / decoder',
+  'tools.entities.intro':
+    'Codeert `&`, `<`, `>`, `"`, `\'` voor veilige HTML-inbedding, of breidt uit naar Latin-1 + valuta + wiskunde + typografische aanhalingstekens. Decodeert elke benoemde of numerieke entiteit.',
+  'tools.entities.mode.aria': 'Coderen of decoderen',
+  'tools.entities.mode.encode': 'Coderen',
+  'tools.entities.mode.decode': 'Decoderen',
+  'tools.entities.variant.label': 'Uitgebreide set (Latin-1 + valuta + wiskunde)',
+  'tools.entities.variant.aria': 'Uitgebreide set wisselen',
+  'tools.entities.variant.minimal': 'Minimaal',
+  'tools.entities.variant.extended': 'Uitgebreid',
+  'tools.entities.label.text': 'Tekst',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Invoer HTML-entiteiten-tool',
+  'tools.entities.result.aria': 'Uitvoer HTML-entiteiten-tool',
+  'tools.entities.placeholder.encode':
+    'Typ of plak — emoji en accenten overleven. Schakel uitgebreid in voor valuta / typografische aanhalingstekens.',
+  'tools.entities.placeholder.decode':
+    'Plak HTML — `&copy;`, `&#65;`, `&#x41;` decoderen. Onbekende entiteiten blijven ongewijzigd.',
+  'tools.entities.entities.found': '{n} entiteiten gedecodeerd',
+  'tools.entities.explainer.minimal.heading': 'Minimaal: de SGML-vijf',
+  'tools.entities.explainer.minimal.body':
+    'Alleen `&`, `<`, `>`, `"`, `\'` worden ge-escaped. Idempotent en juist voor het escapen van gebruikersinput in HTML.',
+  'tools.entities.explainer.extended.heading': 'Uitgebreid: Latin-1 + aanhalingstekens + wiskunde',
+  'tools.entities.explainer.extended.body':
+    'Voegt `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, typografische aanhalingstekens, wiskundige operatoren, pijlen toe. Handig voor zuivere ASCII-HTML na plakken / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numeriek: decimaal en hex',
+  'tools.entities.explainer.numeric.body':
+    'Decodeert zowel `&#65;` (decimaal) als `&#x41;` / `&#X41;` (hex), inclusief astrale codepoints — `&#128512;` en `&#x1F600;` worden beide 😀.',
 };
 
 const pl: Translations = {
@@ -782,6 +950,34 @@ const pl: Translations = {
   'tools.basicauth.heading': 'Pomocnik HTTP Basic Auth',
   'tools.basicauth.intro':
     'Buduje i odczytuje nagłówek `Authorization: Basic <base64>` używany przez uwierzytelnianie HTTP Basic. Wszystko lokalnie — dane nigdy nie opuszczają Twojej przeglądarki.',
+  'tools.entities.heading': 'Encje HTML — koder / dekoder',
+  'tools.entities.intro':
+    'Koduje `&`, `<`, `>`, `"`, `\'` do bezpiecznego osadzania w HTML lub rozszerza do Latin-1 + waluty + matematyka + cudzysłowy typograficzne. Dekoduje dowolną encję nazwaną lub numeryczną.',
+  'tools.entities.mode.aria': 'Koduj lub dekoduj',
+  'tools.entities.mode.encode': 'Koduj',
+  'tools.entities.mode.decode': 'Dekoduj',
+  'tools.entities.variant.label': 'Zestaw rozszerzony (Latin-1 + waluty + matematyka)',
+  'tools.entities.variant.aria': 'Przełącz zestaw rozszerzony',
+  'tools.entities.variant.minimal': 'Minimalny',
+  'tools.entities.variant.extended': 'Rozszerzony',
+  'tools.entities.label.text': 'Tekst',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Wejście narzędzia encji HTML',
+  'tools.entities.result.aria': 'Wyjście narzędzia encji HTML',
+  'tools.entities.placeholder.encode':
+    'Wpisz lub wklej — emoji i akcenty pozostają. Włącz rozszerzony dla walut / cudzysłowów typograficznych.',
+  'tools.entities.placeholder.decode':
+    'Wklej HTML — `&copy;`, `&#65;`, `&#x41;` zdekodują. Nieznane encje przejdą bez zmian.',
+  'tools.entities.entities.found': 'zdekodowano {n} encji',
+  'tools.entities.explainer.minimal.heading': 'Minimalny: pięć SGML',
+  'tools.entities.explainer.minimal.body':
+    'Tylko `&`, `<`, `>`, `"`, `\'` są escapowane. Idempotentny i właściwy do escapowania danych użytkownika osadzanych w HTML.',
+  'tools.entities.explainer.extended.heading': 'Rozszerzony: Latin-1 + cudzysłowy + matematyka',
+  'tools.entities.explainer.extended.body':
+    'Dodaje `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, cudzysłowy typograficzne, operatory matematyczne, strzałki. Przydatny dla czystego ASCII-HTML po wklejeniu / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Numeryczne: dziesiętne i szesnastkowe',
+  'tools.entities.explainer.numeric.body':
+    'Dekoduje zarówno `&#65;` (dziesiętne) jak `&#x41;` / `&#X41;` (hex), w tym astralne codepointy — `&#128512;` i `&#x1F600;` oba dają 😀.',
 };
 
 const ru: Translations = {
@@ -892,6 +1088,34 @@ const ru: Translations = {
   'tools.basicauth.heading': 'Помощник HTTP Basic Auth',
   'tools.basicauth.intro':
     'Собирает и разбирает заголовок `Authorization: Basic <base64>`, используемый HTTP Basic Authentication. Всё локально — учётные данные не покидают браузер.',
+  'tools.entities.heading': 'HTML-сущности — кодировщик / декодер',
+  'tools.entities.intro':
+    'Кодирует `&`, `<`, `>`, `"`, `\'` для безопасной вставки в HTML или расширяет до Latin-1 + валюты + математика + типографские кавычки. Декодирует любую именованную или числовую сущность.',
+  'tools.entities.mode.aria': 'Кодировать или декодировать',
+  'tools.entities.mode.encode': 'Кодировать',
+  'tools.entities.mode.decode': 'Декодировать',
+  'tools.entities.variant.label': 'Расширенный набор (Latin-1 + валюты + математика)',
+  'tools.entities.variant.aria': 'Переключить расширенный набор',
+  'tools.entities.variant.minimal': 'Минимальный',
+  'tools.entities.variant.extended': 'Расширенный',
+  'tools.entities.label.text': 'Текст',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'Вход инструмента HTML-сущностей',
+  'tools.entities.result.aria': 'Выход инструмента HTML-сущностей',
+  'tools.entities.placeholder.encode':
+    'Введите или вставьте — эмодзи и акценты сохраняются. Включите расширенный для валют / кавычек.',
+  'tools.entities.placeholder.decode':
+    'Вставьте HTML — `&copy;`, `&#65;`, `&#x41;` декодируются. Неизвестные сущности проходят без изменений.',
+  'tools.entities.entities.found': 'декодировано {n} сущностей',
+  'tools.entities.explainer.minimal.heading': 'Минимальный: пятёрка SGML',
+  'tools.entities.explainer.minimal.body':
+    'Экранируются только `&`, `<`, `>`, `"`, `\'`. Идемпотентен и правилен для экранирования пользовательского ввода в HTML.',
+  'tools.entities.explainer.extended.heading': 'Расширенный: Latin-1 + кавычки + математика',
+  'tools.entities.explainer.extended.body':
+    'Добавляет `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, типографские кавычки, математические операторы, стрелки. Удобен для чистого ASCII-HTML после вставки / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'Числовые: десятичные и шестнадцатеричные',
+  'tools.entities.explainer.numeric.body':
+    'Декодирует и `&#65;` (десятичное), и `&#x41;` / `&#X41;` (hex), включая астральные кодпойнты — `&#128512;` и `&#x1F600;` оба становятся 😀.',
 };
 
 const tr: Translations = {
@@ -1002,6 +1226,34 @@ const tr: Translations = {
   'tools.basicauth.heading': 'HTTP Basic Auth yardımcısı',
   'tools.basicauth.intro':
     'HTTP Basic Authentication’ın kullandığı `Authorization: Basic <base64>` başlığını oluşturur ve okur. Hepsi cihazda — kimlik bilgileri tarayıcından çıkmaz.',
+  'tools.entities.heading': 'HTML varlıkları — kodlayıcı / çözücü',
+  'tools.entities.intro':
+    'Güvenli HTML gömme için `&`, `<`, `>`, `"`, `\'` karakterlerini kodlar veya Latin-1 + para birimleri + matematik + tipografik tırnaklar setine genişletir. Adlandırılmış veya sayısal varlıkları çözer.',
+  'tools.entities.mode.aria': 'Kodla veya çöz',
+  'tools.entities.mode.encode': 'Kodla',
+  'tools.entities.mode.decode': 'Çöz',
+  'tools.entities.variant.label': 'Genişletilmiş set (Latin-1 + para + matematik)',
+  'tools.entities.variant.aria': 'Genişletilmiş seti aç/kapa',
+  'tools.entities.variant.minimal': 'Minimal',
+  'tools.entities.variant.extended': 'Genişletilmiş',
+  'tools.entities.label.text': 'Metin',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML varlıkları aracı girişi',
+  'tools.entities.result.aria': 'HTML varlıkları aracı çıkışı',
+  'tools.entities.placeholder.encode':
+    'Yaz veya yapıştır — emoji ve aksanlar korunur. Para birimleri / tipografik tırnaklar için genişletilmişi etkinleştir.',
+  'tools.entities.placeholder.decode':
+    'HTML yapıştır — `&copy;`, `&#65;`, `&#x41;` çözülür. Bilinmeyen varlıklar olduğu gibi geçer.',
+  'tools.entities.entities.found': '{n} varlık çözüldü',
+  'tools.entities.explainer.minimal.heading': 'Minimal: SGML beşlisi',
+  'tools.entities.explainer.minimal.body':
+    "Sadece `&`, `<`, `>`, `\"`, `'` kaçırılır. İdempotenttir; kullanıcı girdisini HTML'e gömerken doğru seçim.",
+  'tools.entities.explainer.extended.heading': 'Genişletilmiş: Latin-1 + tırnaklar + matematik',
+  'tools.entities.explainer.extended.body':
+    '`©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, tipografik tırnaklar, matematik operatörleri, oklar eklenir. Yapıştırma / Markdown sonrası saf ASCII-HTML için kullanışlı.',
+  'tools.entities.explainer.numeric.heading': 'Sayısal: ondalık ve onaltılık',
+  'tools.entities.explainer.numeric.body':
+    'Hem `&#65;` (ondalık) hem `&#x41;` / `&#X41;` (hex) çözer; astral kod noktaları dahil — `&#128512;` ve `&#x1F600;` her ikisi de 😀 olur.',
 };
 
 const ja: Translations = {
@@ -1112,6 +1364,34 @@ const ja: Translations = {
   'tools.basicauth.heading': 'HTTP Basic 認証ヘルパー',
   'tools.basicauth.intro':
     'HTTP Basic 認証で使う `Authorization: Basic <base64>` ヘッダを作成・読み取りします。すべて端末内で完結 — 資格情報はブラウザを離れません。',
+  'tools.entities.heading': 'HTML エンティティ — エンコーダ / デコーダ',
+  'tools.entities.intro':
+    '`&`, `<`, `>`, `"`, `\'` を安全な HTML 埋め込み用にエンコード、または Latin-1 + 通貨 + 数学 + 引用符の拡張セットに展開。名前付き・数値エンティティを問わずデコードします。',
+  'tools.entities.mode.aria': 'エンコードまたはデコード',
+  'tools.entities.mode.encode': 'エンコード',
+  'tools.entities.mode.decode': 'デコード',
+  'tools.entities.variant.label': '拡張セット (Latin-1 + 通貨 + 数学)',
+  'tools.entities.variant.aria': '拡張セットの切り替え',
+  'tools.entities.variant.minimal': '最小',
+  'tools.entities.variant.extended': '拡張',
+  'tools.entities.label.text': 'テキスト',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML エンティティツールの入力',
+  'tools.entities.result.aria': 'HTML エンティティツールの出力',
+  'tools.entities.placeholder.encode':
+    '入力または貼り付け — 絵文字とアクセントは保持されます。通貨 / 引用符を含めるには拡張をオンに。',
+  'tools.entities.placeholder.decode':
+    'HTML を貼り付け — `&copy;`, `&#65;`, `&#x41;` はデコードされ、未知のエンティティはそのまま通過します。',
+  'tools.entities.entities.found': '{n} 個のエンティティをデコード',
+  'tools.entities.explainer.minimal.heading': '最小: SGML の 5 文字',
+  'tools.entities.explainer.minimal.body':
+    '`&`, `<`, `>`, `"`, `\'` のみエスケープされます。冪等で、HTML に埋め込むユーザー入力のエスケープに最適。',
+  'tools.entities.explainer.extended.heading': '拡張: Latin-1 + 引用符 + 数学',
+  'tools.entities.explainer.extended.body':
+    '`©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, 引用符、数学演算子、矢印を追加。貼り付け / Markdown 後の純 ASCII-HTML に便利。',
+  'tools.entities.explainer.numeric.heading': '数値: 10 進と 16 進',
+  'tools.entities.explainer.numeric.body':
+    '`&#65;`（10 進）と `&#x41;` / `&#X41;`（16 進）の両方をデコード。アストラル領域コードポイント — `&#128512;` と `&#x1F600;` は両方とも 😀 になります。',
 };
 
 const zh: Translations = {
@@ -1216,6 +1496,34 @@ const zh: Translations = {
   'tools.basicauth.heading': 'HTTP Basic 认证助手',
   'tools.basicauth.intro':
     '生成并读取 HTTP Basic 认证使用的 `Authorization: Basic <base64>` 头。全程本地 — 凭据不会离开你的浏览器。',
+  'tools.entities.heading': 'HTML 实体 — 编码 / 解码',
+  'tools.entities.intro':
+    '编码 `&`, `<`, `>`, `"`, `\'` 用于 HTML 安全嵌入，或扩展到 Latin-1 + 货币 + 数学 + 印刷引号。任意命名或数字实体都能解码。',
+  'tools.entities.mode.aria': '编码或解码',
+  'tools.entities.mode.encode': '编码',
+  'tools.entities.mode.decode': '解码',
+  'tools.entities.variant.label': '扩展集（Latin-1 + 货币 + 数学）',
+  'tools.entities.variant.aria': '切换扩展集',
+  'tools.entities.variant.minimal': '最小',
+  'tools.entities.variant.extended': '扩展',
+  'tools.entities.label.text': '文本',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML 实体工具输入',
+  'tools.entities.result.aria': 'HTML 实体工具输出',
+  'tools.entities.placeholder.encode':
+    '输入或粘贴 — 表情和重音都会保留。需要货币 / 引号请打开扩展。',
+  'tools.entities.placeholder.decode':
+    '粘贴 HTML — `&copy;`、`&#65;`、`&#x41;` 都能解码；未知实体原样保留。',
+  'tools.entities.entities.found': '解码了 {n} 个实体',
+  'tools.entities.explainer.minimal.heading': '最小：SGML 五字符',
+  'tools.entities.explainer.minimal.body':
+    '只转义 `&`, `<`, `>`, `"`, `\'`。幂等，适合把用户输入安全嵌入到 HTML。',
+  'tools.entities.explainer.extended.heading': '扩展：Latin-1 + 引号 + 数学',
+  'tools.entities.explainer.extended.body':
+    '增加 `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`、印刷引号、数学运算符、箭头。适合粘贴 / Markdown 后想得到纯 ASCII-HTML。',
+  'tools.entities.explainer.numeric.heading': '数字：十进制和十六进制',
+  'tools.entities.explainer.numeric.body':
+    '同时解码 `&#65;`（十进制）和 `&#x41;` / `&#X41;`（十六进制），包括星体平面码点 — `&#128512;` 和 `&#x1F600;` 都解码为 😀。',
 };
 
 const ko: Translations = {
@@ -1325,6 +1633,34 @@ const ko: Translations = {
   'tools.basicauth.heading': 'HTTP Basic 인증 헬퍼',
   'tools.basicauth.intro':
     'HTTP Basic 인증이 사용하는 `Authorization: Basic <base64>` 헤더를 생성하고 읽습니다. 모두 로컬에서 — 자격 증명이 브라우저를 떠나지 않습니다.',
+  'tools.entities.heading': 'HTML 엔티티 — 인코더 / 디코더',
+  'tools.entities.intro':
+    '`&`, `<`, `>`, `"`, `\'` 을 안전한 HTML 임베딩용으로 인코딩하거나 Latin-1 + 통화 + 수학 + 인쇄용 따옴표 세트로 확장합니다. 명명·숫자 엔티티 모두 디코딩합니다.',
+  'tools.entities.mode.aria': '인코딩 또는 디코딩',
+  'tools.entities.mode.encode': '인코딩',
+  'tools.entities.mode.decode': '디코딩',
+  'tools.entities.variant.label': '확장 세트 (Latin-1 + 통화 + 수학)',
+  'tools.entities.variant.aria': '확장 세트 토글',
+  'tools.entities.variant.minimal': '최소',
+  'tools.entities.variant.extended': '확장',
+  'tools.entities.label.text': '텍스트',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML 엔티티 도구 입력',
+  'tools.entities.result.aria': 'HTML 엔티티 도구 출력',
+  'tools.entities.placeholder.encode':
+    '입력하거나 붙여넣으세요 — 이모지와 악센트는 유지됩니다. 통화 / 인쇄용 따옴표를 위해 확장을 켜세요.',
+  'tools.entities.placeholder.decode':
+    'HTML을 붙여넣으세요 — `&copy;`, `&#65;`, `&#x41;`은 디코딩되고 알 수 없는 엔티티는 그대로 통과합니다.',
+  'tools.entities.entities.found': '{n}개 엔티티 디코딩됨',
+  'tools.entities.explainer.minimal.heading': '최소: SGML 다섯 문자',
+  'tools.entities.explainer.minimal.body':
+    '`&`, `<`, `>`, `"`, `\'`만 이스케이프됩니다. 멱등적이며 HTML에 임베딩할 사용자 입력 이스케이프에 적합합니다.',
+  'tools.entities.explainer.extended.heading': '확장: Latin-1 + 따옴표 + 수학',
+  'tools.entities.explainer.extended.body':
+    '`©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, 인쇄용 따옴표, 수학 연산자, 화살표 추가. 붙여넣기 / Markdown 후 순수 ASCII-HTML에 유용합니다.',
+  'tools.entities.explainer.numeric.heading': '숫자: 10진수와 16진수',
+  'tools.entities.explainer.numeric.body':
+    '`&#65;`(10진수)와 `&#x41;` / `&#X41;`(16진수) 모두 디코딩되며, 별자리 코드포인트 포함 — `&#128512;`와 `&#x1F600;`는 둘 다 😀이 됩니다.',
 };
 
 const hi: Translations = {
@@ -1435,6 +1771,34 @@ const hi: Translations = {
   'tools.basicauth.heading': 'HTTP Basic Auth मददगार',
   'tools.basicauth.intro':
     'HTTP Basic प्रमाणीकरण का `Authorization: Basic <base64>` हेडर बनाता और पढ़ता है। सब डिवाइस पर — क्रेडेंशियल ब्राउज़र से बाहर नहीं जाते।',
+  'tools.entities.heading': 'HTML एंटिटीज़ — एनकोडर / डिकोडर',
+  'tools.entities.intro':
+    '`&`, `<`, `>`, `"`, `\'` को सुरक्षित HTML एम्बेडिंग के लिए एनकोड करता है, या Latin-1 + करेंसी + गणित + टाइपोग्राफिक कोट्स तक बढ़ा देता है। नामित या संख्यात्मक — कोई भी एंटिटी डिकोड कर देता है।',
+  'tools.entities.mode.aria': 'एनकोड या डिकोड',
+  'tools.entities.mode.encode': 'एनकोड',
+  'tools.entities.mode.decode': 'डिकोड',
+  'tools.entities.variant.label': 'विस्तारित सेट (Latin-1 + करेंसी + गणित)',
+  'tools.entities.variant.aria': 'विस्तारित सेट टॉगल',
+  'tools.entities.variant.minimal': 'न्यूनतम',
+  'tools.entities.variant.extended': 'विस्तारित',
+  'tools.entities.label.text': 'पाठ',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML एंटिटीज़ टूल इनपुट',
+  'tools.entities.result.aria': 'HTML एंटिटीज़ टूल आउटपुट',
+  'tools.entities.placeholder.encode':
+    'टाइप या पेस्ट करो — इमोजी और एक्सेंट रहते हैं। करेंसी / टाइपोग्राफिक कोट्स के लिए विस्तारित ऑन करो।',
+  'tools.entities.placeholder.decode':
+    'HTML पेस्ट करो — `&copy;`, `&#65;`, `&#x41;` डिकोड होते हैं। अज्ञात एंटिटी जैसी की तैसी रहती हैं।',
+  'tools.entities.entities.found': '{n} एंटिटी डिकोड हुईं',
+  'tools.entities.explainer.minimal.heading': 'न्यूनतम: SGML के पाँच',
+  'tools.entities.explainer.minimal.body':
+    'सिर्फ़ `&`, `<`, `>`, `"`, `\'` एस्केप होते हैं। आइडेम्पोटेंट और HTML में उपयोगकर्ता इनपुट एम्बेड करते समय सही विकल्प।',
+  'tools.entities.explainer.extended.heading': 'विस्तारित: Latin-1 + कोट्स + गणित',
+  'tools.entities.explainer.extended.body':
+    '`©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, टाइपोग्राफिक कोट्स, गणितीय ऑपरेटर, तीर जोड़ता है। पेस्ट / Markdown के बाद शुद्ध ASCII-HTML के लिए काम का।',
+  'tools.entities.explainer.numeric.heading': 'संख्यात्मक: दशमलव और हेक्साडेसिमल',
+  'tools.entities.explainer.numeric.body':
+    '`&#65;` (दशमलव) और `&#x41;` / `&#X41;` (हेक्स) दोनों डिकोड करता है, खगोलीय कोडपॉइंट सहित — `&#128512;` और `&#x1F600;` दोनों 😀 बनते हैं।',
 };
 
 const ar: Translations = {
@@ -1543,6 +1907,34 @@ const ar: Translations = {
   'tools.basicauth.heading': 'مساعد HTTP Basic Auth',
   'tools.basicauth.intro':
     'يُنشئ ويقرأ ترويسة `Authorization: Basic <base64>` التي يستخدمها مصادقة HTTP Basic. كلّه محلي — لا تغادر بياناتك المتصفّح.',
+  'tools.entities.heading': 'كيانات HTML — مُرمِّز / مفكِّك',
+  'tools.entities.intro':
+    'يُرمِّز `&`, `<`, `>`, `"`, `\'` للتضمين الآمن في HTML، أو يتوسّع إلى مجموعة Latin-1 + العملات + الرياضيات + علامات التنصيص الطباعية. يفكّ أي كيان مُسمّى أو رقمي.',
+  'tools.entities.mode.aria': 'ترميز أو فك ترميز',
+  'tools.entities.mode.encode': 'ترميز',
+  'tools.entities.mode.decode': 'فك ترميز',
+  'tools.entities.variant.label': 'مجموعة موسّعة (Latin-1 + عملات + رياضيات)',
+  'tools.entities.variant.aria': 'تبديل المجموعة الموسّعة',
+  'tools.entities.variant.minimal': 'الحد الأدنى',
+  'tools.entities.variant.extended': 'موسّعة',
+  'tools.entities.label.text': 'نص',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'مدخل أداة كيانات HTML',
+  'tools.entities.result.aria': 'مخرج أداة كيانات HTML',
+  'tools.entities.placeholder.encode':
+    'اكتب أو الصق — تبقى الإيموجي واللواحق. فعّل الموسّعة للعملات / علامات التنصيص الطباعية.',
+  'tools.entities.placeholder.decode':
+    'الصق HTML — `&copy;`, `&#65;`, `&#x41;` تُفكّ، والكيانات غير المعروفة تمرّ كما هي.',
+  'tools.entities.entities.found': 'تم فكّ {n} كيانًا',
+  'tools.entities.explainer.minimal.heading': 'الحد الأدنى: خماسي SGML',
+  'tools.entities.explainer.minimal.body':
+    'تُهرب فقط `&`, `<`, `>`, `"`, `\'`. عملية متماثلة (idempotent) ومناسبة لتهريب مدخلات المستخدم عند التضمين في HTML.',
+  'tools.entities.explainer.extended.heading': 'موسّعة: Latin-1 + علامات تنصيص + رياضيات',
+  'tools.entities.explainer.extended.body':
+    'يُضيف `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`، علامات التنصيص الطباعية، عوامل الرياضيات، الأسهم. مفيد لإنتاج HTML بـ ASCII خالص بعد لصق / Markdown.',
+  'tools.entities.explainer.numeric.heading': 'رقمي: عشري وست عشري',
+  'tools.entities.explainer.numeric.body':
+    'يفكّ كلًّا من `&#65;` (عشري) و `&#x41;` / `&#X41;` (ست عشري)، بما في ذلك نقاط الكود السماوية — `&#128512;` و `&#x1F600;` كلاهما يُعطي 😀.',
 };
 
 export const ALL_TRANSLATIONS: Record<string, Translations> = {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -118,6 +118,36 @@ const en: Translations = {
   'tools.basicauth.heading': 'HTTP Basic Auth helper',
   'tools.basicauth.intro':
     'Builds and reads the `Authorization: Basic <base64>` header used by HTTP Basic Authentication. All on-device — credentials never leave your browser.',
+
+  // Day 3 — html-entities
+  'tools.entities.heading': 'HTML entities encoder / decoder',
+  'tools.entities.intro':
+    'Encode `&`, `<`, `>`, `"`, `\'` (the SGML-five) for safe HTML embedding, or extend to the full Latin-1 + currency + math + curly-quotes set. Decode any named or numeric entity (`&copy;`, `&#65;`, `&#x41;`).',
+  'tools.entities.mode.aria': 'Encode or decode',
+  'tools.entities.mode.encode': 'Encode',
+  'tools.entities.mode.decode': 'Decode',
+  'tools.entities.variant.label': 'Extended set (Latin-1 + currency + math)',
+  'tools.entities.variant.aria': 'Toggle extended encode set',
+  'tools.entities.variant.minimal': 'Minimal',
+  'tools.entities.variant.extended': 'Extended',
+  'tools.entities.label.text': 'Text',
+  'tools.entities.label.html': 'HTML',
+  'tools.entities.source.aria': 'HTML entities tool input',
+  'tools.entities.result.aria': 'HTML entities tool output',
+  'tools.entities.placeholder.encode':
+    'Type or paste — emoji and accents survive. Toggle extended for currency / curly quotes.',
+  'tools.entities.placeholder.decode':
+    'Paste HTML — `&copy;`, `&#65;`, `&#x41;` all decode. Unknown entities pass through untouched.',
+  'tools.entities.entities.found': '{n} entities decoded',
+  'tools.entities.explainer.minimal.heading': 'Minimal: the SGML-five',
+  'tools.entities.explainer.minimal.body':
+    'Only `&`, `<`, `>`, `"`, `\'` get escaped. Idempotent on re-decode and the right call when escaping user input for safe HTML embedding (server-rendered templates, attributes).',
+  'tools.entities.explainer.extended.heading': 'Extended: Latin-1 + curly quotes + math',
+  'tools.entities.explainer.extended.body':
+    'Adds `©`, `®`, `™`, `€`, `£`, `¥`, `–`, `—`, `…`, `“ ”`, `‘ ’`, math operators, arrows. Use when you want the source HTML to be ASCII-only after a Markdown / paste.',
+  'tools.entities.explainer.numeric.heading': 'Numeric: decimal and hex',
+  'tools.entities.explainer.numeric.body':
+    'Decode handles both `&#65;` (decimal) and `&#x41;` / `&#X41;` (hex), including astral codepoints — `&#128512;` and `&#x1F600;` both round-trip to 😀.',
 };
 
 export default en;

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -121,6 +121,30 @@ export interface Translations {
   // detected/persisted locale.
   'topbar.language.aria': string;
   'topbar.language.label': string;
+
+  // Day 3 — html-entities (encoder/decoder for named + numeric entities)
+  'tools.entities.heading': string;
+  'tools.entities.intro': string;
+  'tools.entities.mode.aria': string;
+  'tools.entities.mode.encode': string;
+  'tools.entities.mode.decode': string;
+  'tools.entities.variant.label': string;
+  'tools.entities.variant.aria': string;
+  'tools.entities.variant.minimal': string;
+  'tools.entities.variant.extended': string;
+  'tools.entities.label.text': string;
+  'tools.entities.label.html': string;
+  'tools.entities.source.aria': string;
+  'tools.entities.result.aria': string;
+  'tools.entities.placeholder.encode': string;
+  'tools.entities.placeholder.decode': string;
+  'tools.entities.entities.found': string;
+  'tools.entities.explainer.minimal.heading': string;
+  'tools.entities.explainer.minimal.body': string;
+  'tools.entities.explainer.extended.heading': string;
+  'tools.entities.explainer.extended.body': string;
+  'tools.entities.explainer.numeric.heading': string;
+  'tools.entities.explainer.numeric.body': string;
 }
 
 export type TranslationKey = keyof Translations;

--- a/src/tools/01-encoding/003-html-entities/entities.ts
+++ b/src/tools/01-encoding/003-html-entities/entities.ts
@@ -1,0 +1,221 @@
+/**
+ * Subset of HTML5 named character references.
+ *
+ * The full WHATWG named-character-reference table is ~2,200 entries (~25 KB
+ * JSON). This module ships the practical subset that covers >95 % of real
+ * HTML decoding tasks: the legacy SGML "five" (`& < > " '`), Latin-1
+ * Supplement (U+00A0 – U+00FF), Greek lowercase, common math/punctuation,
+ * curly quotes, dashes, currency, and the few archaic-but-frequent ones
+ * (`&copy;`, `&trade;`, `&nbsp;`, `&hellip;`, `&mdash;`, etc.).
+ *
+ * Source: https://html.spec.whatwg.org/multipage/named-characters.html
+ *
+ * Exported as two parallel maps so encoding (char → entity) and decoding
+ * (entity → char) are O(1) and the bundle stays small.
+ *
+ * If the user pastes an entity outside this set, decode falls through to
+ * leave the raw text unchanged — that's intentional, lossy decoding is
+ * worse than partial decoding.
+ */
+
+/** Always-required (the SGML legacy five). Used by `encodeMinimal`. */
+export const MINIMAL_ENCODE: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/** Extended encode set — adds the Latin-1 Supplement, currency, dashes,
+ *  curly quotes, and common math symbols on top of the minimal five. */
+export const EXTENDED_ENCODE: Readonly<Record<string, string>> = {
+  ...MINIMAL_ENCODE,
+  ' ': '&nbsp;',
+  '¡': '&iexcl;',
+  '¢': '&cent;',
+  '£': '&pound;',
+  '¤': '&curren;',
+  '¥': '&yen;',
+  '¦': '&brvbar;',
+  '§': '&sect;',
+  '¨': '&uml;',
+  '©': '&copy;',
+  'ª': '&ordf;',
+  '«': '&laquo;',
+  '¬': '&not;',
+  '­': '&shy;',
+  '®': '&reg;',
+  '¯': '&macr;',
+  '°': '&deg;',
+  '±': '&plusmn;',
+  '²': '&sup2;',
+  '³': '&sup3;',
+  '´': '&acute;',
+  'µ': '&micro;',
+  '¶': '&para;',
+  '·': '&middot;',
+  '¸': '&cedil;',
+  '¹': '&sup1;',
+  'º': '&ordm;',
+  '»': '&raquo;',
+  '¼': '&frac14;',
+  '½': '&frac12;',
+  '¾': '&frac34;',
+  '¿': '&iquest;',
+  'À': '&Agrave;',
+  'Á': '&Aacute;',
+  'Â': '&Acirc;',
+  'Ã': '&Atilde;',
+  'Ä': '&Auml;',
+  'Å': '&Aring;',
+  'Æ': '&AElig;',
+  'Ç': '&Ccedil;',
+  'È': '&Egrave;',
+  'É': '&Eacute;',
+  'Ê': '&Ecirc;',
+  'Ë': '&Euml;',
+  'Ì': '&Igrave;',
+  'Í': '&Iacute;',
+  'Î': '&Icirc;',
+  'Ï': '&Iuml;',
+  'Ð': '&ETH;',
+  'Ñ': '&Ntilde;',
+  'Ò': '&Ograve;',
+  'Ó': '&Oacute;',
+  'Ô': '&Ocirc;',
+  'Õ': '&Otilde;',
+  'Ö': '&Ouml;',
+  '×': '&times;',
+  'Ø': '&Oslash;',
+  'Ù': '&Ugrave;',
+  'Ú': '&Uacute;',
+  'Û': '&Ucirc;',
+  'Ü': '&Uuml;',
+  'Ý': '&Yacute;',
+  'Þ': '&THORN;',
+  'ß': '&szlig;',
+  'à': '&agrave;',
+  'á': '&aacute;',
+  'â': '&acirc;',
+  'ã': '&atilde;',
+  'ä': '&auml;',
+  'å': '&aring;',
+  'æ': '&aelig;',
+  'ç': '&ccedil;',
+  'è': '&egrave;',
+  'é': '&eacute;',
+  'ê': '&ecirc;',
+  'ë': '&euml;',
+  'ì': '&igrave;',
+  'í': '&iacute;',
+  'î': '&icirc;',
+  'ï': '&iuml;',
+  'ð': '&eth;',
+  'ñ': '&ntilde;',
+  'ò': '&ograve;',
+  'ó': '&oacute;',
+  'ô': '&ocirc;',
+  'õ': '&otilde;',
+  'ö': '&ouml;',
+  '÷': '&divide;',
+  'ø': '&oslash;',
+  'ù': '&ugrave;',
+  'ú': '&uacute;',
+  'û': '&ucirc;',
+  'ü': '&uuml;',
+  'ý': '&yacute;',
+  'þ': '&thorn;',
+  'ÿ': '&yuml;',
+  // Currency / math / punctuation outside Latin-1
+  '€': '&euro;',
+  '™': '&trade;',
+  '–': '&ndash;',
+  '—': '&mdash;',
+  '‘': '&lsquo;',
+  '’': '&rsquo;',
+  '“': '&ldquo;',
+  '”': '&rdquo;',
+  '…': '&hellip;',
+  '†': '&dagger;',
+  '‡': '&Dagger;',
+  '•': '&bull;',
+  '‰': '&permil;',
+  '′': '&prime;',
+  '″': '&Prime;',
+  '←': '&larr;',
+  '↑': '&uarr;',
+  '→': '&rarr;',
+  '↓': '&darr;',
+  '↔': '&harr;',
+  '⇐': '&lArr;',
+  '⇑': '&uArr;',
+  '⇒': '&rArr;',
+  '⇓': '&dArr;',
+  '⇔': '&hArr;',
+  '∀': '&forall;',
+  '∂': '&part;',
+  '∃': '&exist;',
+  '∅': '&empty;',
+  '∇': '&nabla;',
+  '∈': '&isin;',
+  '∉': '&notin;',
+  '∋': '&ni;',
+  '∏': '&prod;',
+  '∑': '&sum;',
+  '−': '&minus;',
+  '∗': '&lowast;',
+  '√': '&radic;',
+  '∝': '&prop;',
+  '∞': '&infin;',
+  '∠': '&ang;',
+  '∧': '&and;',
+  '∨': '&or;',
+  '∩': '&cap;',
+  '∪': '&cup;',
+  '∫': '&int;',
+  '∴': '&there4;',
+  '∼': '&sim;',
+  '≅': '&cong;',
+  '≈': '&asymp;',
+  '≠': '&ne;',
+  '≡': '&equiv;',
+  '≤': '&le;',
+  '≥': '&ge;',
+  '⊂': '&sub;',
+  '⊃': '&sup;',
+  '⊆': '&sube;',
+  '⊇': '&supe;',
+  '⊕': '&oplus;',
+  '⊗': '&otimes;',
+  '⊥': '&perp;',
+  '⋅': '&sdot;',
+  '⌈': '&lceil;',
+  '⌉': '&rceil;',
+  '⌊': '&lfloor;',
+  '⌋': '&rfloor;',
+  '〈': '&lang;',
+  '〉': '&rang;',
+  '◊': '&loz;',
+  '♠': '&spades;',
+  '♣': '&clubs;',
+  '♥': '&hearts;',
+  '♦': '&diams;',
+};
+
+/** Decoder map — inverse of EXTENDED_ENCODE plus a few historical aliases
+ *  for common DOM-quirks (`&apos;`, `&AMP;`, etc.). */
+export const DECODE_MAP: Readonly<Record<string, string>> = (() => {
+  const map: Record<string, string> = {};
+  for (const [ch, ent] of Object.entries(EXTENDED_ENCODE)) {
+    // Strip leading `&` and trailing `;` for keying.
+    map[ent.slice(1, -1)] = ch;
+  }
+  // Aliases that appear in the wild.
+  map.apos = "'";
+  map.AMP = '&';
+  map.LT = '<';
+  map.GT = '>';
+  map.QUOT = '"';
+  return map;
+})();

--- a/src/tools/01-encoding/003-html-entities/index.ts
+++ b/src/tools/01-encoding/003-html-entities/index.ts
@@ -1,0 +1,18 @@
+import type { ToolModule } from '../../../lib/types';
+import { render } from './render';
+import { DEFAULT_STATE, parseParams, serializeParams, type State } from './url-state';
+
+export const tool: ToolModule<State> = {
+  id: 'html-entities',
+  number: 3,
+  category: '01-encoding',
+  name: 'HTML entities encoder/decoder',
+  description:
+    'Encode the SGML-five (or extended Latin-1 + currency + math + curly quotes) and decode any named or numeric entity (`&copy;`, `&#65;`, `&#x41;`).',
+  tags: ['html', 'entities', 'encoding', 'unicode', 'decode'],
+  parseParams,
+  serializeParams,
+  render,
+};
+
+export { DEFAULT_STATE };

--- a/src/tools/01-encoding/003-html-entities/logic.test.ts
+++ b/src/tools/01-encoding/003-html-entities/logic.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { countEntities, decode, encode, roundTripsCleanly } from './logic';
+
+const NBSP = ' ';
+
+describe('encode (minimal variant)', () => {
+  it('escapes the SGML-five', () => {
+    expect(encode('a & b < c > d " e \' f', 'minimal')).toBe(
+      'a &amp; b &lt; c &gt; d &quot; e &#39; f',
+    );
+  });
+
+  it('leaves Latin-1 supplement chars untouched (minimal mode)', () => {
+    expect(encode('café — €5', 'minimal')).toBe('café — €5');
+  });
+
+  it('encoded `&amp;` is NOT idempotent on the literal level', () => {
+    // Note: re-encoding `&amp;` in minimal mode produces `&amp;amp;` because
+    // the literal `&` is escaped again. The round-trip via decode IS clean,
+    // covered by the round-trip test below.
+    expect(encode('&', 'minimal')).toBe('&amp;');
+    expect(encode(encode('&', 'minimal'), 'minimal')).toBe('&amp;amp;');
+  });
+});
+
+describe('encode (extended variant)', () => {
+  it('escapes Latin-1 supplement + currency + dashes (regular spaces stay)', () => {
+    expect(encode('café — €5', 'extended')).toBe('caf&eacute; &mdash; &euro;5');
+  });
+
+  it('escapes copyright and trademark', () => {
+    expect(encode('© 2026 — ™ Pratiyush', 'extended')).toBe(
+      '&copy; 2026 &mdash; &trade; Pratiyush',
+    );
+  });
+
+  it('escapes curly quotes', () => {
+    expect(encode('“hello” ‘world’', 'extended')).toBe('&ldquo;hello&rdquo; &lsquo;world&rsquo;');
+  });
+
+  it('still escapes the SGML-five even in extended mode', () => {
+    expect(encode('<a href="x">', 'extended')).toBe('&lt;a href=&quot;x&quot;&gt;');
+  });
+
+  it('escapes the actual NBSP (U+00A0) — only that one, not regular spaces', () => {
+    expect(encode(`a b${NBSP}c d`, 'extended')).toBe('a b&nbsp;c d');
+  });
+});
+
+describe('decode', () => {
+  it('decodes the SGML-five', () => {
+    expect(decode('a &amp; b &lt; c &gt; d &quot; e &#39; f')).toBe(
+      'a & b < c > d " e \' f',
+    );
+  });
+
+  it('decodes &apos; (XML alias)', () => {
+    expect(decode('hello &apos;world&apos;')).toBe("hello 'world'");
+  });
+
+  it('decodes the all-caps DOM aliases', () => {
+    expect(decode('&AMP;&LT;&GT;&QUOT;')).toBe('&<>"');
+  });
+
+  it('decodes named entities outside the SGML-five', () => {
+    expect(decode('&copy; 2026 &mdash; &trade;')).toBe('© 2026 — ™');
+  });
+
+  it('decodes decimal numeric entities', () => {
+    expect(decode('&#65;&#66;&#67;')).toBe('ABC');
+  });
+
+  it('decodes hex numeric entities (lowercase x)', () => {
+    expect(decode('&#x48;&#x69;')).toBe('Hi');
+  });
+
+  it('decodes hex numeric entities (uppercase X)', () => {
+    expect(decode('&#X48;&#X69;')).toBe('Hi');
+  });
+
+  it('decodes astral codepoints (emoji)', () => {
+    expect(decode('&#128512;')).toBe('😀');
+    expect(decode('&#x1F600;')).toBe('😀');
+  });
+
+  it('leaves unknown entities intact', () => {
+    expect(decode('hello &madeup; world')).toBe('hello &madeup; world');
+  });
+
+  it('leaves out-of-range numeric entities intact', () => {
+    expect(decode('&#9999999999;')).toBe('&#9999999999;');
+    expect(decode('&#x110000;')).toBe('&#x110000;');
+  });
+
+  it('decodes a mix of named, decimal, and hex in one pass', () => {
+    expect(decode('&copy; A&#66;&#x43; — &eacute;')).toBe('© ABC — é');
+  });
+});
+
+describe('roundTripsCleanly', () => {
+  it('round-trips ASCII via minimal', () => {
+    const input = '<script>alert("x" & y)</script>';
+    expect(roundTripsCleanly(input, 'minimal')).toBe(true);
+  });
+
+  it('round-trips Latin-1 via extended', () => {
+    expect(roundTripsCleanly('café résumé', 'extended')).toBe(true);
+  });
+
+  it('round-trips currency + math via extended', () => {
+    expect(roundTripsCleanly('€5 ≤ £6 → ¥7', 'extended')).toBe(true);
+  });
+
+  it('round-trips copyright/trademark via extended', () => {
+    expect(roundTripsCleanly('© 2026 ™ Pratiyush', 'extended')).toBe(true);
+  });
+});
+
+describe('countEntities', () => {
+  it('returns 0 for entity-free input', () => {
+    expect(countEntities('hello world')).toBe(0);
+  });
+
+  it('counts named entities', () => {
+    expect(countEntities('&amp; and &lt; and &gt;')).toBe(3);
+  });
+
+  it('counts numeric entities (decimal + hex)', () => {
+    expect(countEntities('&#65;&#x42;&#67;')).toBe(3);
+  });
+
+  it('counts mixed entity kinds', () => {
+    expect(countEntities('&copy; &#169; &#xa9;')).toBe(3);
+  });
+});

--- a/src/tools/01-encoding/003-html-entities/logic.ts
+++ b/src/tools/01-encoding/003-html-entities/logic.ts
@@ -1,0 +1,72 @@
+/**
+ * HTML entity encoder / decoder.
+ *
+ * Two encode modes:
+ *   - **minimal** — escapes only `& < > " '` (the SGML-five). Idempotent
+ *     and suitable for safe inline-HTML embedding of user input.
+ *   - **extended** — adds Latin-1 Supplement, currency, math, dashes,
+ *     curly quotes, and a few archaic-but-frequent symbols. Useful when
+ *     you want a shareable representation of pasted content (Markdown
+ *     paste-safe, email subject lines, RSS).
+ *
+ * Decode is one mode: it understands every entity from `extended`, the
+ * five aliases (`apos`, `AMP`, etc.), AND numeric forms — decimal
+ * (`&#65;`) and hexadecimal (`&#x41;` / `&#X41;`).
+ *
+ * Anything outside the table is left intact rather than mangled — better
+ * to surface "I don't know that entity" than to silently corrupt input.
+ */
+
+import { DECODE_MAP, EXTENDED_ENCODE, MINIMAL_ENCODE } from './entities';
+
+export type EncodeVariant = 'minimal' | 'extended';
+
+/** Escape characters per the chosen variant. Idempotent only for `minimal`. */
+export function encode(input: string, variant: EncodeVariant = 'minimal'): string {
+  const table = variant === 'extended' ? EXTENDED_ENCODE : MINIMAL_ENCODE;
+  let out = '';
+  for (const ch of input) {
+    out += table[ch] ?? ch;
+  }
+  return out;
+}
+
+/** Decode named + numeric entities. Lossless on round-trip with `encode`. */
+export function decode(input: string): string {
+  // Match: &<name>; OR &#<digits>; OR &#x<hex>;
+  return input.replace(
+    /&(?:#(x?)([0-9a-f]+)|([a-z][a-z0-9]+));/gi,
+    (match: string, x: string | undefined, num: string | undefined, name: string | undefined) => {
+      if (num !== undefined) {
+        const codepoint = parseInt(num, x ? 16 : 10);
+        if (!Number.isFinite(codepoint) || codepoint < 0 || codepoint > 0x10ffff) {
+          return match;
+        }
+        try {
+          return String.fromCodePoint(codepoint);
+        } catch {
+          return match;
+        }
+      }
+      if (name !== undefined) {
+        const ch = DECODE_MAP[name];
+        return ch ?? match;
+      }
+      return match;
+    },
+  );
+}
+
+/** True when `input` is byte-for-byte identical after a round-trip
+ *  encode → decode under the given variant. Used in tests; surfaced as a
+ *  property the UI can verify. */
+export function roundTripsCleanly(input: string, variant: EncodeVariant): boolean {
+  return decode(encode(input, variant)) === input;
+}
+
+/** Counts entities found in a string, useful for surfacing a "decoded N
+ *  entities" hint to the user. Matches the same pattern as `decode`. */
+export function countEntities(input: string): number {
+  const matches = input.match(/&(?:#x?[0-9a-f]+|[a-z][a-z0-9]+);/gi);
+  return matches ? matches.length : 0;
+}

--- a/src/tools/01-encoding/003-html-entities/render.ts
+++ b/src/tools/01-encoding/003-html-entities/render.ts
@@ -1,0 +1,335 @@
+import { translate } from '../../../lib/i18n';
+import { copyButton, type CopyButtonHandle } from '../../../ui/primitives/copy-button';
+import { panel } from '../../../ui/primitives/panel';
+import { pasteButton, type PasteButtonHandle } from '../../../ui/primitives/paste-button';
+import { textarea } from '../../../ui/primitives/textarea';
+import { countEntities, decode, encode } from './logic';
+import { type Mode, type State } from './url-state';
+
+export interface RenderOptions {
+  onStateChange?: (next: State) => void;
+}
+
+export function render(
+  host: HTMLElement,
+  initial: State,
+  options: RenderOptions = {},
+): { dispose(): void } {
+  const doc = host.ownerDocument;
+  let state: State = { ...initial };
+  const disposers: (() => void)[] = [];
+
+  const root = doc.createElement('div');
+  root.classList.add('dt-base64'); // Reuse the base64 layout shell
+
+  // ─── Heading + intro ───────────────────────────────────────────────────
+  const heading = doc.createElement('h1');
+  heading.classList.add('dt-basicauth__heading');
+  heading.textContent = translate('tools.entities.heading');
+  root.appendChild(heading);
+
+  const intro = doc.createElement('p');
+  intro.classList.add('dt-basicauth__intro');
+  appendInline(intro, translate('tools.entities.intro'));
+  root.appendChild(intro);
+
+  // ─── Top control bar: mode tabs + variant toggle (encode-only) ────────
+  const controls = doc.createElement('div');
+  controls.classList.add('dt-base64__controls');
+
+  const tabs = doc.createElement('div');
+  tabs.classList.add('dt-base64__segmented');
+  tabs.setAttribute('role', 'tablist');
+  tabs.setAttribute('aria-label', translate('tools.entities.mode.aria'));
+  const encodeTab = makeTab('encode', translate('tools.entities.mode.encode'));
+  const decodeTab = makeTab('decode', translate('tools.entities.mode.decode'));
+  tabs.append(encodeTab, decodeTab);
+  controls.appendChild(tabs);
+
+  // Variant switch — visible in encode mode only.
+  const variantWrap = doc.createElement('label');
+  variantWrap.classList.add('dt-base64__switch');
+  const variantInput = doc.createElement('input');
+  variantInput.type = 'checkbox';
+  variantInput.classList.add('dt-base64__switch-input');
+  variantInput.checked = state.variant === 'extended';
+  const variantVisual = doc.createElement('span');
+  variantVisual.classList.add('dt-base64__switch-visual');
+  variantVisual.setAttribute('aria-hidden', 'true');
+  const variantText = doc.createElement('span');
+  variantText.classList.add('dt-base64__switch-label');
+  variantText.textContent = translate('tools.entities.variant.label');
+  variantWrap.append(variantInput, variantVisual, variantText);
+  controls.appendChild(variantWrap);
+
+  variantInput.addEventListener('change', () => {
+    update({ variant: variantInput.checked ? 'extended' : 'minimal' });
+  });
+
+  root.appendChild(controls);
+
+  // ─── Two-pane workspace ───────────────────────────────────────────────
+  const workspace = doc.createElement('div');
+  workspace.classList.add('dt-base64__workspace');
+
+  // Source (editable)
+  const sourceArea = textarea({
+    value: state.input,
+    placeholder: placeholderFor(state.mode),
+    ariaLabel: translate('tools.entities.source.aria'),
+    rows: 10,
+    onInput: (value) => {
+      update({ input: value });
+    },
+  });
+  sourceArea.classList.add('dt-base64__textarea');
+
+  const sourcePaneBody = doc.createElement('div');
+  sourcePaneBody.classList.add('dt-base64__pane-body');
+  sourcePaneBody.appendChild(sourceArea);
+
+  const pasteHandle: PasteButtonHandle = pasteButton({
+    label: translate('tools.base64.paste'),
+    pastedLabel: translate('tools.base64.pasted'),
+    onPaste: (text) => {
+      sourceArea.value = text;
+      update({ input: text });
+      sourceArea.focus();
+    },
+    onError: () => {
+      const previous = sourceArea.title;
+      sourceArea.title = translate('error.paste.failed');
+      setTimeout(() => {
+        sourceArea.title = previous;
+      }, 4000);
+    },
+  });
+  pasteHandle.el.classList.add('dt-base64__paste');
+  pasteHandle.el.setAttribute('aria-label', translate('tools.base64.paste.aria'));
+  disposers.push(() => {
+    pasteHandle.dispose();
+  });
+
+  const sourceFoot = doc.createElement('div');
+  sourceFoot.classList.add('dt-base64__pane-foot');
+  const sourceLengths = doc.createElement('span');
+  sourceLengths.classList.add('dt-base64__lengths');
+  sourceFoot.append(sourceLengths, pasteHandle.el);
+  sourcePaneBody.appendChild(sourceFoot);
+
+  const sourcePane = panel({
+    label: sourceLabel(state.mode),
+    body: sourcePaneBody,
+    className: 'dt-base64__pane',
+  });
+  const sourceLabelEl = sourcePane.querySelector<HTMLDivElement>('.dt-panel__label');
+  workspace.appendChild(sourcePane);
+
+  // Swap (mode flip + content swap)
+  const swap = doc.createElement('button');
+  swap.type = 'button';
+  swap.classList.add('dt-base64__swap');
+  swap.setAttribute('aria-label', translate('tools.base64.swap'));
+  swap.title = translate('tools.base64.swap');
+  swap.innerHTML = '<span aria-hidden="true">⇄</span>';
+  swap.addEventListener('click', () => {
+    const computed = computeOutput(state);
+    const nextMode: Mode = state.mode === 'encode' ? 'decode' : 'encode';
+    sourceArea.value = computed;
+    update({ mode: nextMode, input: computed });
+  });
+  workspace.appendChild(swap);
+
+  // Result (read-only)
+  const resultArea = textarea({
+    value: '',
+    ariaLabel: translate('tools.entities.result.aria'),
+    rows: 10,
+    readonly: true,
+  });
+  resultArea.classList.add('dt-base64__textarea', 'dt-base64__textarea--mono');
+
+  const resultFootInfo = doc.createElement('span');
+  resultFootInfo.classList.add('dt-base64__lengths');
+
+  const copyHandle: CopyButtonHandle = copyButton({
+    text: () => resultArea.value,
+    label: translate('tools.base64.copy'),
+  });
+  copyHandle.el.classList.add('dt-base64__copy');
+  disposers.push(() => {
+    copyHandle.dispose();
+  });
+
+  const resultPaneBody = doc.createElement('div');
+  resultPaneBody.classList.add('dt-base64__pane-body');
+  resultPaneBody.appendChild(resultArea);
+
+  const resultFoot = doc.createElement('div');
+  resultFoot.classList.add('dt-base64__pane-foot');
+  resultFoot.append(resultFootInfo, copyHandle.el);
+  resultPaneBody.appendChild(resultFoot);
+
+  const resultPane = panel({
+    label: resultLabel(state.mode),
+    body: resultPaneBody,
+    className: 'dt-base64__pane',
+  });
+  const resultLabelEl = resultPane.querySelector<HTMLDivElement>('.dt-panel__label');
+  workspace.appendChild(resultPane);
+
+  root.appendChild(workspace);
+
+  // ─── Explainer ─────────────────────────────────────────────────────────
+  root.appendChild(buildExplainer(doc));
+
+  // Initial paint
+  setActiveTab(state.mode);
+  applyVariantVisibility();
+  refreshOutput();
+  host.appendChild(root);
+
+  return {
+    dispose(): void {
+      for (const fn of disposers) fn();
+      if (root.parentNode === host) host.removeChild(root);
+    },
+  };
+
+  // ─── helpers ────────────────────────────────────────────────────────────
+
+  function makeTab(id: Mode, label: string): HTMLButtonElement {
+    const btn = doc.createElement('button');
+    btn.type = 'button';
+    btn.classList.add('dt-base64__tab');
+    btn.dataset.mode = id;
+    btn.setAttribute('role', 'tab');
+    btn.textContent = label;
+    btn.addEventListener('click', () => {
+      update({ mode: id });
+    });
+    return btn;
+  }
+
+  function setActiveTab(mode: Mode): void {
+    for (const tab of [encodeTab, decodeTab]) {
+      const isActive = tab.dataset.mode === mode;
+      tab.classList.toggle('dt-base64__tab--active', isActive);
+      tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    }
+  }
+
+  function applyVariantVisibility(): void {
+    // Variant switch only matters for encode; hide it in decode mode so the
+    // user isn't tempted to flip an irrelevant control.
+    variantWrap.style.display = state.mode === 'encode' ? '' : 'none';
+  }
+
+  function update(patch: Partial<State>): void {
+    const prevMode = state.mode;
+    state = { ...state, ...patch };
+    if (state.mode !== prevMode) {
+      setActiveTab(state.mode);
+      applyVariantVisibility();
+      sourceArea.placeholder = placeholderFor(state.mode);
+      if (sourceLabelEl) sourceLabelEl.textContent = sourceLabel(state.mode);
+      if (resultLabelEl) resultLabelEl.textContent = resultLabel(state.mode);
+    }
+    if (state.variant !== (variantInput.checked ? 'extended' : 'minimal')) {
+      variantInput.checked = state.variant === 'extended';
+    }
+    if (sourceArea.value !== state.input) {
+      sourceArea.value = state.input;
+    }
+    refreshOutput();
+    options.onStateChange?.(state);
+  }
+
+  function refreshOutput(): void {
+    const value = computeOutput(state);
+    resultArea.value = value;
+    sourceLengths.textContent = translate('tools.base64.chars', { n: String(state.input.length) });
+    if (state.mode === 'decode') {
+      const found = countEntities(state.input);
+      resultFootInfo.textContent = translate('tools.entities.entities.found', { n: String(found) });
+    } else {
+      resultFootInfo.textContent = translate('tools.base64.chars', { n: String(value.length) });
+    }
+  }
+}
+
+function computeOutput(state: State): string {
+  if (state.input === '') return '';
+  return state.mode === 'encode' ? encode(state.input, state.variant) : decode(state.input);
+}
+
+function sourceLabel(mode: Mode): string {
+  return mode === 'encode'
+    ? translate('tools.entities.label.text')
+    : translate('tools.entities.label.html');
+}
+
+function resultLabel(mode: Mode): string {
+  return mode === 'encode'
+    ? translate('tools.entities.label.html')
+    : translate('tools.entities.label.text');
+}
+
+function placeholderFor(mode: Mode): string {
+  return mode === 'encode'
+    ? translate('tools.entities.placeholder.encode')
+    : translate('tools.entities.placeholder.decode');
+}
+
+/** Append a translated string with `inline-code` segments to a parent element. */
+function appendInline(parent: HTMLElement, text: string): void {
+  const parts = text.split('`');
+  parts.forEach((part, i) => {
+    if (part === '') return;
+    if (i % 2 === 0) {
+      parent.appendChild(document.createTextNode(part));
+    } else {
+      const code = document.createElement('code');
+      code.textContent = part;
+      parent.appendChild(code);
+    }
+  });
+}
+
+/** The explainer block — three <details> sections (minimal, extended, numeric). */
+function buildExplainer(doc: Document): HTMLElement {
+  const section = doc.createElement('section');
+  section.classList.add('dt-base64__explainer');
+
+  const renderDetails = (titleKey: string, bodyKey: string): HTMLDetailsElement => {
+    const d = doc.createElement('details');
+    d.classList.add('dt-base64__deepdive');
+    const sum = doc.createElement('summary');
+    sum.classList.add('dt-base64__deepdive-summary');
+    sum.textContent = translate(titleKey as never);
+    d.appendChild(sum);
+    const p = doc.createElement('p');
+    p.classList.add('dt-base64__explainer-p');
+    appendInline(p, translate(bodyKey as never));
+    d.appendChild(p);
+    return d;
+  };
+
+  section.appendChild(
+    renderDetails('tools.entities.explainer.minimal.heading', 'tools.entities.explainer.minimal.body'),
+  );
+  section.appendChild(
+    renderDetails(
+      'tools.entities.explainer.extended.heading',
+      'tools.entities.explainer.extended.body',
+    ),
+  );
+  section.appendChild(
+    renderDetails(
+      'tools.entities.explainer.numeric.heading',
+      'tools.entities.explainer.numeric.body',
+    ),
+  );
+
+  return section;
+}

--- a/src/tools/01-encoding/003-html-entities/url-state.test.ts
+++ b/src/tools/01-encoding/003-html-entities/url-state.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_STATE, parseParams, serializeParams } from './url-state';
+
+describe('parseParams', () => {
+  it('returns default state for empty params', () => {
+    expect(parseParams(new URLSearchParams(), new URLSearchParams())).toEqual(DEFAULT_STATE);
+  });
+
+  it('reads mode=decode from search', () => {
+    expect(
+      parseParams(new URLSearchParams('mode=decode'), new URLSearchParams()).mode,
+    ).toBe('decode');
+  });
+
+  it('treats unrecognized mode values as encode', () => {
+    expect(
+      parseParams(new URLSearchParams('mode=garbage'), new URLSearchParams()).mode,
+    ).toBe('encode');
+  });
+
+  it('reads variant=extended from search', () => {
+    expect(
+      parseParams(new URLSearchParams('variant=extended'), new URLSearchParams()).variant,
+    ).toBe('extended');
+  });
+
+  it('treats unrecognized variant values as minimal', () => {
+    expect(
+      parseParams(new URLSearchParams('variant=ultra'), new URLSearchParams()).variant,
+    ).toBe('minimal');
+  });
+
+  it('reads input from hash params (privacy: keeps it out of search)', () => {
+    const state = parseParams(
+      new URLSearchParams(),
+      new URLSearchParams('in=hello+%26+world'),
+    );
+    expect(state.input).toBe('hello & world');
+  });
+});
+
+describe('serializeParams', () => {
+  it('emits empty search/hash for default state', () => {
+    const { search, hash } = serializeParams(DEFAULT_STATE);
+    expect(search.toString()).toBe('');
+    expect(hash.toString()).toBe('');
+  });
+
+  it('omits mode when it is encode (the default)', () => {
+    const { search } = serializeParams({ ...DEFAULT_STATE, mode: 'encode' });
+    expect(search.has('mode')).toBe(false);
+  });
+
+  it('emits mode=decode', () => {
+    const { search } = serializeParams({ ...DEFAULT_STATE, mode: 'decode' });
+    expect(search.get('mode')).toBe('decode');
+  });
+
+  it('emits variant=extended', () => {
+    const { search } = serializeParams({ ...DEFAULT_STATE, variant: 'extended' });
+    expect(search.get('variant')).toBe('extended');
+  });
+
+  it('puts input in hash, never in search', () => {
+    const { search, hash } = serializeParams({ ...DEFAULT_STATE, input: 'hello & world' });
+    expect(search.has('in')).toBe(false);
+    expect(hash.get('in')).toBe('hello & world');
+  });
+
+  it('round-trips through parse', () => {
+    const original = {
+      mode: 'decode' as const,
+      variant: 'extended' as const,
+      input: '<a href="x">© 2026</a>',
+    };
+    const { search, hash } = serializeParams(original);
+    expect(parseParams(search, hash)).toEqual(original);
+  });
+});

--- a/src/tools/01-encoding/003-html-entities/url-state.ts
+++ b/src/tools/01-encoding/003-html-entities/url-state.ts
@@ -1,0 +1,49 @@
+/**
+ * URL-state contract for the html-entities tool.
+ *
+ * Privacy: input may contain Latin-1 / non-ASCII characters that don't
+ * round-trip through HTTP query strings unscathed. Per the project rule
+ * ([feedback_url_parameters](memory)), `input` lives in the URL hash, not
+ * the search string. `mode` and `variant` are non-secret and ride in
+ * the search params so they're shareable as part of a quick link.
+ */
+
+import type { EncodeVariant } from './logic';
+
+export type Mode = 'encode' | 'decode';
+
+export interface State {
+  readonly mode: Mode;
+  readonly variant: EncodeVariant;
+  readonly input: string;
+}
+
+export const DEFAULT_STATE: State = {
+  mode: 'encode',
+  variant: 'minimal',
+  input: '',
+};
+
+export function parseParams(search: URLSearchParams, hash: URLSearchParams): State {
+  const modeRaw = search.get('mode');
+  const mode: Mode = modeRaw === 'decode' ? 'decode' : 'encode';
+  const variantRaw = search.get('variant');
+  const variant: EncodeVariant = variantRaw === 'extended' ? 'extended' : 'minimal';
+  return {
+    mode,
+    variant,
+    input: hash.get('in') ?? DEFAULT_STATE.input,
+  };
+}
+
+export function serializeParams(state: State): {
+  search: URLSearchParams;
+  hash: URLSearchParams;
+} {
+  const search = new URLSearchParams();
+  const hash = new URLSearchParams();
+  if (state.mode !== DEFAULT_STATE.mode) search.set('mode', state.mode);
+  if (state.variant !== DEFAULT_STATE.variant) search.set('variant', state.variant);
+  if (state.input) hash.set('in', state.input);
+  return { search, hash };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { ToolModule } from '../lib/types';
 import { tool as base64StringConverter } from './01-encoding/001-base64-string-converter';
 import { tool as base64BasicAuth } from './01-encoding/002-base64-basic-auth';
+import { tool as htmlEntities } from './01-encoding/003-html-entities';
 
 // Auto-managed by `pnpm new-tool`. Add new tool imports above the closing `];`.
 // Each tool module's state generic is widened to `never` for the registry —
@@ -8,4 +9,5 @@ import { tool as base64BasicAuth } from './01-encoding/002-base64-basic-auth';
 export const TOOLS: readonly ToolModule<never>[] = [
   base64StringConverter as unknown as ToolModule<never>,
   base64BasicAuth as unknown as ToolModule<never>,
+  htmlEntities as unknown as ToolModule<never>,
 ];

--- a/tests/e2e/html-entities.spec.ts
+++ b/tests/e2e/html-entities.spec.ts
@@ -1,0 +1,84 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+import type { Result as AxeResult } from 'axe-core';
+
+/**
+ * Day 3 — html-entities encoder/decoder.
+ *
+ * Verifies:
+ *   1. Encode mode minimal — &<>"' escape, accents pass through
+ *   2. Encode mode extended — accents become named entities
+ *   3. Decode mode — named + numeric (decimal & hex) all decode
+ *   4. URL-hash deep-link survives a reload
+ *   5. WCAG 2.1 AA via axe-core under every theme
+ */
+
+const TOOL_PATH = '/developer-tools/#/html-entities';
+
+test.describe('html-entities', () => {
+  test('encode minimal — escapes the SGML-five only', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const input = page.getByLabel(/HTML entities tool input/i);
+    const output = page.getByLabel(/HTML entities tool output/i);
+    await input.fill('café <a href="x">© & ©</a>');
+    // Minimal mode is default → accents stay as-is, only &<>"' escape.
+    await expect(output).toHaveValue('café &lt;a href=&quot;x&quot;&gt;© &amp; ©&lt;/a&gt;', {
+      timeout: 2000,
+    });
+  });
+
+  test('encode extended — accents and copyright become named entities', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const toggle = page.getByLabel(/Extended set/i);
+    await toggle.check();
+    const input = page.getByLabel(/HTML entities tool input/i);
+    const output = page.getByLabel(/HTML entities tool output/i);
+    await input.fill('café — © Pratiyush');
+    await expect(output).toHaveValue('caf&eacute; &mdash; &copy; Pratiyush', { timeout: 2000 });
+  });
+
+  test('decode — named, decimal, and hex entities all decode', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    await page.getByRole('tab', { name: /Decode/i }).click();
+    const input = page.getByLabel(/HTML entities tool input/i);
+    const output = page.getByLabel(/HTML entities tool output/i);
+    await input.fill('&copy; A&#66;&#x43; — &eacute;');
+    await expect(output).toHaveValue('© ABC — é', { timeout: 2000 });
+  });
+
+  test('input persists in URL hash for sharing', async ({ page }) => {
+    await page.goto(TOOL_PATH);
+    const input = page.getByLabel(/HTML entities tool input/i);
+    await input.fill('share-me');
+    await page.waitForFunction(() => window.location.hash.includes('in='));
+    expect(page.url()).toContain('in=share-me');
+  });
+});
+
+const A11Y_THEMES = ['clean', 'linear', 'vercel', 'paper', 'swiss', 'aurora', 'matrix'] as const;
+
+test.describe('a11y — html-entities', () => {
+  for (const theme of A11Y_THEMES) {
+    test(`has no detectable WCAG 2.1 AA violations under ${theme}`, async ({ page }) => {
+      await page.goto(TOOL_PATH);
+      await page.evaluate((t) => {
+        localStorage.setItem('dt.theme', t);
+      }, theme);
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'])
+        .analyze();
+
+      expect.soft(results.violations, formatViolations(results.violations)).toEqual([]);
+    });
+  }
+});
+
+function formatViolations(violations: readonly AxeResult[]): string {
+  if (violations.length === 0) return 'no violations';
+  return violations
+    .map((v) => `[${v.impact ?? 'unknown'}] ${v.id}: ${v.description}\n  → ${v.helpUrl}`)
+    .join('\n');
+}


### PR DESCRIPTION
## Summary

Day 3 of the 100 dev tools / 100 days plan. Closes the gap most online HTML entity tools leave: they handle `& < > " '` and silently miss `&copy;`, `&nbsp;`, `&eacute;`, and the rest of the practical ~150-entity set.

### Encode

Two variants, picked by a toggle on the workspace:

- **Minimal** — only the SGML-five. Idempotent on re-decode. Right for escaping user input embedded in HTML.
- **Extended** — adds Latin-1 supplement + currency (€ £ ¥) + dashes (– —) + ellipsis + curly quotes (" " ' ') + math operators (≤ ≥ ≠) + arrows. ~150 entities total.

### Decode

Handles every form in the wild:

- Named: `&copy;` → ©
- Decimal: `&#65;` → A
- Hex: `&#x41;` / `&#X41;` → A
- All-caps DOM aliases: `&AMP;`, `&LT;`, `&APOS;`, `&QUOT;`
- Astral codepoints: `&#128512;` and `&#x1F600;` → 😀
- Unknown entities pass through untouched (lossy decoding is worse than partial)

### UX

- Mode tabs + variant toggle (variant hidden in decode mode where it doesn't apply)
- "{N} entities decoded" counter on the result pane in decode mode
- URL hash deep-link (`#in=...`) — input never appears in the query / Referer
- Three-section explainer: **Minimal**, **Extended**, **Numeric**
- Same paste/copy primitives + Ken Burns short-video pipeline as Days 1/2

### Tests

- 27 new logic tests (round-trip discipline, NBSP-vs-space subtlety, numeric edge cases)
- 9 new url-state tests
- 4 new functional e2e + 7 axe-core a11y per theme
- **Total: 179/179 unit · 35/35 chromium e2e + axe**

### i18n

- 25 new keys translated across all 15 locales

### Marketing

Bonus, in this PR:

- Long videos deleted (per "shorts only" decision); audio kept under `audio/long.mp3` for re-cuts
- Short-video pipeline upgraded — captions baked in via Playwright (zero-freetype workaround), Ken Burns zoompan, fade transitions, brand pill in corner
- Day 2 social posts (twitter / linkedin / instagram-reel / youtube-short) backfilled
- Day 3 social posts shipped: hook tweet + 5-tweet thread, LinkedIn long-form, Instagram Reel caption, YouTube Short title/description/chapters

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (15 pre-existing console-warn warnings on scripts/sync-translations.ts only)
- [x] `pnpm test` — 179/179 passing
- [x] `pnpm exec playwright test --project=chromium` — 35/35 passing
- [x] Manual mobile (375 px) + desktop verification on the html-entities tool
- [x] Round-trip cleanliness verified for ASCII, Latin-1, currency, math, copyright, trademark, emoji