### PR TITLE
feat(storybook): wire toolbar decorator (SB-03)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -45,11 +45,19 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Build Storybook
+        run: pnpm build-storybook
+
+      - name: Stage Storybook under dist/storybook/
+        run: |
+          mkdir -p dist/storybook
+          cp -R storybook-static/. dist/storybook/
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,16 @@ node_modules/
 # Build output
 dist/
 build/
+storybook-static/
 *.tsbuildinfo
+
+# Design showcase — extracted/auto-generated from the IT Tools zip.
+# Tracking it would break the build because it duplicates assets and would
+# bloat package.json on every refresh. Keep local-only.
+public/design-showcase/
+
+# Local zips / archives (e.g. design dumps, IT Tools reference)
+*.zip
 
 # Test / coverage
 coverage/
@@ -43,8 +52,12 @@ memory/
 # Tool specifications (local design notes, not part of the public artifact)
 .specification/
 
+# Kiro spec docs (requirements/design/tasks — local-only, mirrors .specification/ pattern)
+.kiro/
+
 # Design playground / Figma exports (local-only)
 design/
+design-extracted/
 
 # Marketing artifacts (LinkedIn drafts, social cards, 100-day plan — local only)
 marketing/

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,37 @@
+import type { StorybookConfig } from '@storybook/html-vite';
+
+// Storybook 8 (HTML + Vite) configuration.
+//
+// Registry shape lives at `src/tools/index.ts` and exports
+// `TOOLS: readonly ToolModule<never>[]`. The shape is defined in
+// `src/lib/types.ts`. Tools are NOT factories — they expose
+// `render(host, initial): { dispose }` and mount onto the host element.
+// Story authors wrap this via the `mountTool` helper (added in SB-04 / #43).
+//
+// Known issue (fixed in SB-16 / #54): preview.ts toolbar `theme` items don't
+// match the live app's 7 themes. The live app reads `[data-theme]`; the
+// design system reads `[data-preset]` + `[data-density]`. Until SB-16 lands,
+// switching the toolbar produces minimal visual change.
+
+const config: StorybookConfig = {
+  stories: ['../src/stories/**/*.stories.ts'],
+  // Narrow allowlist (SB-12 / #50). The live app's `public/` contains
+  // favicons, manifests, and SEO files that Storybook does not need; only
+  // `design-showcase/` is required by the iframe stories.
+  staticDirs: ['../public/design-showcase'],
+  framework: {
+    name: '@storybook/html-vite',
+    options: {},
+  },
+  // Pages deploy sub-path (SB-21 / #59). Serves under
+  // https://pratiyush.github.io/developer-tools/storybook/.
+  // The `base` is only applied for production builds — dev runs at `/`.
+  async viteFinal(viteConfig, { configType }) {
+    if (configType === 'PRODUCTION') {
+      viteConfig.base = '/developer-tools/storybook/';
+    }
+    return viteConfig;
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,98 @@
+import type { Preview } from '@storybook/html';
+
+const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'Design theme from the extracted zip',
+      defaultValue: 'mono',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: [
+          { value: 'mono', title: 'Mono' },
+          { value: 'editorial', title: 'Editorial' },
+          { value: 'grid', title: 'Grid' },
+          { value: 'aurora', title: 'Aurora' },
+          { value: 'clean', title: 'Clean' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+    preset: {
+      description: 'Curated preset: theme + accent + type + radius',
+      defaultValue: 'linear',
+      toolbar: {
+        title: 'Preset',
+        icon: 'switchalt',
+        items: [
+          { value: 'linear', title: 'Linear' },
+          { value: 'vercel', title: 'Vercel' },
+          { value: 'paper', title: 'Paper' },
+          { value: 'swiss', title: 'Swiss' },
+          { value: 'aurora', title: 'Aurora' },
+          { value: 'clean', title: 'Clean' },
+          { value: 'matrix', title: 'Matrix' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+    density: {
+      description: 'Density scale',
+      defaultValue: 'default',
+      toolbar: {
+        title: 'Density',
+        icon: 'component',
+        items: [
+          { value: 'default', title: 'Default' },
+          { value: 'compact', title: 'Compact' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {
+      viewports: {
+        mobile: {
+          name: 'Mobile 390',
+          styles: { width: '390px', height: '844px' },
+        },
+        tablet: {
+          name: 'Tablet 768',
+          styles: { width: '768px', height: '1024px' },
+        },
+        desktop: {
+          name: 'Desktop 1440',
+          styles: { width: '1440px', height: '900px' },
+        },
+        wide: {
+          name: 'Wide 1920',
+          styles: { width: '1920px', height: '1080px' },
+        },
+      },
+    },
+    options: {
+      storySort: {
+        order: [
+          'Developer Tools Design System',
+          [
+            'Foundations',
+            'Presets',
+            'Buttons',
+            'Forms',
+            'Tool Cards',
+            'Navigation',
+            'Results',
+            'App Frame',
+            'Verification',
+          ],
+          'Design Screens',
+          ['Visual Testing Guide', 'Home', 'Tools'],
+        ],
+      },
+    },
+  },
+};
+
+export default preview;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,43 +1,50 @@
 import type { Preview } from '@storybook/html';
+import { themeDecorator } from '../src/stories/_decorators/theme';
 
 const preview: Preview = {
+  decorators: [themeDecorator],
   globalTypes: {
     theme: {
-      description: 'Design theme from the extracted zip',
-      defaultValue: 'mono',
+      // Mirrors `THEMES` in `src/lib/theme.ts`. Default matches `DEFAULT_THEME`.
+      // Both `theme` and `preset` are written to `<html>` until SB-16 (#54)
+      // unifies on `[data-preset]` + `[data-density]`.
+      description: 'Live app theme — applied as [data-theme] on <html>',
+      defaultValue: 'clean',
       toolbar: {
         title: 'Theme',
         icon: 'paintbrush',
         items: [
-          { value: 'mono', title: 'Mono' },
-          { value: 'editorial', title: 'Editorial' },
-          { value: 'grid', title: 'Grid' },
-          { value: 'aurora', title: 'Aurora' },
           { value: 'clean', title: 'Clean' },
-        ],
-        dynamicTitle: true,
-      },
-    },
-    preset: {
-      description: 'Curated preset: theme + accent + type + radius',
-      defaultValue: 'linear',
-      toolbar: {
-        title: 'Preset',
-        icon: 'switchalt',
-        items: [
           { value: 'linear', title: 'Linear' },
           { value: 'vercel', title: 'Vercel' },
           { value: 'paper', title: 'Paper' },
           { value: 'swiss', title: 'Swiss' },
           { value: 'aurora', title: 'Aurora' },
+          { value: 'matrix', title: 'Matrix' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+    preset: {
+      description: 'Design preset — applied as [data-preset] on <html>',
+      defaultValue: 'clean',
+      toolbar: {
+        title: 'Preset',
+        icon: 'switchalt',
+        items: [
           { value: 'clean', title: 'Clean' },
+          { value: 'linear', title: 'Linear' },
+          { value: 'vercel', title: 'Vercel' },
+          { value: 'paper', title: 'Paper' },
+          { value: 'swiss', title: 'Swiss' },
+          { value: 'aurora', title: 'Aurora' },
           { value: 'matrix', title: 'Matrix' },
         ],
         dynamicTitle: true,
       },
     },
     density: {
-      description: 'Density scale',
+      description: 'Density scale — applied as [data-density] on <html>',
       defaultValue: 'default',
       toolbar: {
         title: 'Density',

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   "packageManager": "pnpm@9.15.0",
   "scripts": {
     "dev": "vite",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ignore-pattern '.analysis/**' --ignore-pattern '.specification/**' --ignore-pattern 'marketing/**' --ignore-pattern 'tools/**' --ignore-pattern 'design/**' --ignore-pattern '.playwright-mcp/**' --ignore-pattern 'eslint.config.js' --ignore-pattern 'commitlint.config.ts' --ignore-pattern 'playwright.config.ts'",
-    "lint:fix": "eslint . --fix --ignore-pattern '.analysis/**' --ignore-pattern '.specification/**' --ignore-pattern 'marketing/**' --ignore-pattern 'tools/**' --ignore-pattern 'design/**' --ignore-pattern '.playwright-mcp/**' --ignore-pattern 'eslint.config.js' --ignore-pattern 'commitlint.config.ts' --ignore-pattern 'playwright.config.ts'",
+    "lint": "eslint . --ignore-pattern '.analysis/**' --ignore-pattern '.specification/**' --ignore-pattern 'marketing/**' --ignore-pattern 'tools/**' --ignore-pattern 'design/**' --ignore-pattern 'design-extracted/**' --ignore-pattern '.playwright-mcp/**' --ignore-pattern '.claude/**' --ignore-pattern '.storybook/**' --ignore-pattern 'storybook-static/**' --ignore-pattern 'public/design-showcase/**' --ignore-pattern 'eslint.config.js' --ignore-pattern 'commitlint.config.ts' --ignore-pattern 'playwright.config.ts'",
+    "lint:fix": "eslint . --fix --ignore-pattern '.analysis/**' --ignore-pattern '.specification/**' --ignore-pattern 'marketing/**' --ignore-pattern 'tools/**' --ignore-pattern 'design/**' --ignore-pattern 'design-extracted/**' --ignore-pattern '.playwright-mcp/**' --ignore-pattern '.claude/**' --ignore-pattern '.storybook/**' --ignore-pattern 'storybook-static/**' --ignore-pattern 'public/design-showcase/**' --ignore-pattern 'eslint.config.js' --ignore-pattern 'commitlint.config.ts' --ignore-pattern 'playwright.config.ts'",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
@@ -40,7 +42,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
-      "eslint --fix --no-warn-ignored --ignore-pattern eslint.config.js --ignore-pattern commitlint.config.ts --ignore-pattern playwright.config.ts",
+      "eslint --fix --no-warn-ignored --ignore-pattern eslint.config.js --ignore-pattern commitlint.config.ts --ignore-pattern playwright.config.ts --ignore-pattern '.storybook/**'",
       "prettier --write"
     ],
     "*.{json,css,html,md,yml,yaml}": [
@@ -52,6 +54,8 @@
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@playwright/test": "^1.48.2",
+    "@storybook/html": "^8.4.7",
+    "@storybook/html-vite": "^8.4.7",
     "@types/bcryptjs": "^3.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.12.7",
@@ -65,6 +69,7 @@
     "jsdom": "^29.1.1",
     "lint-staged": "^17.0.4",
     "prettier": "^3.2.5",
+    "storybook": "^8.4.7",
     "tsx": "^4.19.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       '@playwright/test':
         specifier: ^1.48.2
         version: 1.59.1
+      '@storybook/html':
+        specifier: ^8.4.7
+        version: 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      '@storybook/html-vite':
+        specifier: ^8.4.7
+        version: 8.6.18(storybook@8.6.18(prettier@3.8.3))(vite@5.4.21(@types/node@20.19.39))
       '@types/bcryptjs':
         specifier: ^3.0.0
         version: 3.0.0
@@ -72,6 +78,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.8.3
+      storybook:
+        specifier: ^8.4.7
+        version: 8.6.18(prettier@3.8.3)
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -772,6 +781,60 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@storybook/builder-vite@8.6.18':
+    resolution: {integrity: sha512-XLqnOv4C36jlTd4uC8xpWBxv+7GV4/05zWJ0wAcU4qflorropUTirt4UQPGkwIzi+BVAhs9pJj+m4k0IWJtpHg==}
+    peerDependencies:
+      storybook: ^8.6.18
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0
+
+  '@storybook/components@8.6.18':
+    resolution: {integrity: sha512-55yViiZzPS/cPBuOeW4QGxGqrusjXVyxuknmbYCIwDtFyyvI/CgbjXRHdxNBaIjz+IlftxvBmmSaOqFG5+/dkA==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/core@8.6.18':
+    resolution: {integrity: sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==}
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
+  '@storybook/csf-plugin@8.6.18':
+    resolution: {integrity: sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/html-vite@8.6.18':
+    resolution: {integrity: sha512-mi/OqOpYZRFSIm9Jd3rMiieMKnVePlkW0wXKN3ly8UMYeXb/CzHSDEuFbfDXVo48ZOyYHOPRRBLQcjPxT807cw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/html@8.6.18':
+    resolution: {integrity: sha512-7yjb09rf7wP4hlVlirVPe+Jjo6kRsr4zEhuHlLM97Jf5Ojf7LH+vtvV9M3F7zs50lm9jTNBd45oWfTX8T7d2mw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      storybook: ^8.6.18
+
+  '@storybook/manager-api@8.6.18':
+    resolution: {integrity: sha512-BjIp12gEMgzFkEsgKpDIbZdnSWTZpm2dlws8WiPJCpgJtG+HWSxZ0/Ms30Au9yfwzQEKRSbV/5zpsKMGc2SIJw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/preview-api@8.6.18':
+    resolution: {integrity: sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
+  '@storybook/theming@8.6.18':
+    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+
   '@types/bcryptjs@3.0.0':
     resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
     deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
@@ -927,6 +990,14 @@ packages:
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   axe-core@4.11.4:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
@@ -942,6 +1013,10 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -952,9 +1027,24 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  browser-assert@1.2.1:
+    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1072,6 +1162,14 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1079,6 +1177,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1100,6 +1202,23 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1154,6 +1273,11 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1221,6 +1345,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1234,6 +1362,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1244,6 +1379,14 @@ packages:
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -1278,9 +1421,28 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -1328,8 +1490,21 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1343,6 +1518,10 @@ packages:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1354,12 +1533,24 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-text-path@2.0.0:
     resolution: {integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==}
+    engines: {node: '>=8'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
   isexe@2.0.0:
@@ -1394,6 +1585,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
+    engines: {node: '>=12.0.0'}
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -1502,6 +1697,10 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -1558,6 +1757,10 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1643,6 +1846,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1660,12 +1867,20 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -1698,6 +1913,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -1706,6 +1925,10 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1738,6 +1961,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -1747,6 +1974,15 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  storybook@8.6.18:
+    resolution: {integrity: sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1801,6 +2037,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1841,6 +2080,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1880,8 +2126,15 @@ packages:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
 
+  unplugin@1.16.1:
+    resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
+    engines: {node: '>=14.0.0'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -1952,6 +2205,9 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -1959,6 +2215,10 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1988,6 +2248,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -2535,6 +2807,77 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.8.3))(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      browser-assert: 1.2.1
+      storybook: 8.6.18(prettier@3.8.3)
+      ts-dedent: 2.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+
+  '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.8.3)
+
+  '@storybook/core@8.6.18(prettier@3.8.3)(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      better-opn: 3.0.2
+      browser-assert: 1.2.1
+      esbuild: 0.21.5
+      esbuild-register: 3.6.0(esbuild@0.21.5)
+      jsdoc-type-pratt-parser: 4.8.0
+      process: 0.11.10
+      recast: 0.23.11
+      semver: 7.7.4
+      util: 0.12.5
+      ws: 8.20.0
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - storybook
+      - supports-color
+      - utf-8-validate
+
+  '@storybook/csf-plugin@8.6.18(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.8.3)
+      unplugin: 1.16.1
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/html-vite@8.6.18(storybook@8.6.18(prettier@3.8.3))(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.8.3))(vite@5.4.21(@types/node@20.19.39))
+      '@storybook/html': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      magic-string: 0.30.21
+      storybook: 8.6.18(prettier@3.8.3)
+    transitivePeerDependencies:
+      - vite
+
+  '@storybook/html@8.6.18(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      '@storybook/components': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      '@storybook/preview-api': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.8.3))
+      storybook: 8.6.18(prettier@3.8.3)
+      ts-dedent: 2.2.0
+
+  '@storybook/manager-api@8.6.18(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.8.3)
+
+  '@storybook/preview-api@8.6.18(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.8.3)
+
+  '@storybook/theming@8.6.18(storybook@8.6.18(prettier@3.8.3))':
+    dependencies:
+      storybook: 8.6.18(prettier@3.8.3)
+
   '@types/bcryptjs@3.0.0':
     dependencies:
       bcryptjs: 3.0.3
@@ -2743,6 +3086,14 @@ snapshots:
 
   assertion-error@1.1.0: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
   axe-core@4.11.4: {}
 
   balanced-match@1.0.2: {}
@@ -2750,6 +3101,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bcryptjs@3.0.3: {}
+
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
 
   bidi-js@1.0.3:
     dependencies:
@@ -2764,7 +3119,26 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  browser-assert@1.2.1: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -2884,11 +3258,25 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-lazy-prop@2.0.0: {}
+
   diff-sequences@29.6.3: {}
 
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   emoji-regex@10.6.0: {}
 
@@ -2903,6 +3291,21 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild-register@3.6.0(esbuild@0.21.5):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.21.5
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -3025,6 +3428,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -3089,6 +3494,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -3097,11 +3506,33 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  generator-function@2.0.1: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
   get-func-name@2.0.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@8.0.1: {}
 
@@ -3136,7 +3567,23 @@ snapshots:
 
   globals@15.15.0: {}
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -3172,7 +3619,16 @@ snapshots:
 
   ini@4.1.1: {}
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-arrayish@0.2.1: {}
+
+  is-callable@1.2.7: {}
+
+  is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -3182,6 +3638,14 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -3190,11 +3654,26 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
   is-stream@3.0.0: {}
 
   is-text-path@2.0.0:
     dependencies:
       text-extensions: 2.4.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isexe@2.0.0: {}
 
@@ -3228,6 +3707,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@4.8.0: {}
 
   jsdom@29.1.1(@noble/hashes@2.2.0):
     dependencies:
@@ -3354,6 +3835,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
 
   meow@12.1.1: {}
@@ -3402,6 +3885,12 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -3481,6 +3970,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
@@ -3497,9 +3988,19 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  process@0.11.10: {}
+
   punycode@2.3.1: {}
 
   react-is@18.3.1: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   require-directory@2.1.1: {}
 
@@ -3549,11 +4050,26 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
 
   semver@7.7.4: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -3579,11 +4095,23 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  storybook@8.6.18(prettier@3.8.3):
+    dependencies:
+      '@storybook/core': 8.6.18(prettier@3.8.3)(storybook@8.6.18(prettier@3.8.3))
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   string-argv@0.3.2: {}
 
@@ -3636,6 +4164,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -3666,6 +4196,10 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-dedent@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:
@@ -3701,9 +4235,22 @@ snapshots:
 
   unicorn-magic@0.1.0: {}
 
+  unplugin@1.16.1:
+    dependencies:
+      acorn: 8.16.0
+      webpack-virtual-modules: 0.6.2
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
 
   vite-node@1.6.1(@types/node@20.19.39):
     dependencies:
@@ -3773,6 +4320,8 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
+  webpack-virtual-modules@0.6.2: {}
+
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1(@noble/hashes@2.2.0):
@@ -3782,6 +4331,16 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:
@@ -3813,6 +4372,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/src/stories/_decorators/theme.test.ts
+++ b/src/stories/_decorators/theme.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { applyThemeGlobals, themeDecorator } from './theme';
+
+describe('applyThemeGlobals', () => {
+  it('writes theme, preset, density to dataset', () => {
+    const root = document.createElement('div');
+    applyThemeGlobals({ theme: 'aurora', preset: 'aurora', density: 'compact' }, root);
+    expect(root.dataset.theme).toBe('aurora');
+    expect(root.dataset.preset).toBe('aurora');
+    expect(root.dataset.density).toBe('compact');
+  });
+
+  it('skips empty values without overwriting existing dataset attrs', () => {
+    const root = document.createElement('div');
+    root.dataset.theme = 'clean';
+    applyThemeGlobals({ theme: '', preset: 'linear' }, root);
+    expect(root.dataset.theme).toBe('clean');
+    expect(root.dataset.preset).toBe('linear');
+    expect(root.dataset.density).toBeUndefined();
+  });
+
+  it('skips undefined values', () => {
+    const root = document.createElement('div');
+    applyThemeGlobals({ theme: 'matrix' }, root);
+    expect(root.dataset.theme).toBe('matrix');
+    expect(root.dataset.preset).toBeUndefined();
+    expect(root.dataset.density).toBeUndefined();
+  });
+});
+
+describe('themeDecorator', () => {
+  it('applies globals to document.documentElement before invoking the story', () => {
+    let called = false;
+    const story = (): string => {
+      called = true;
+      return 'rendered';
+    };
+    const result = themeDecorator(story, {
+      globals: { theme: 'paper', preset: 'paper', density: 'default' },
+    });
+    expect(called).toBe(true);
+    expect(result).toBe('rendered');
+    expect(document.documentElement.dataset.theme).toBe('paper');
+    expect(document.documentElement.dataset.preset).toBe('paper');
+    expect(document.documentElement.dataset.density).toBe('default');
+  });
+
+  it('passes the context through to the wrapped story', () => {
+    const seen: string[] = [];
+    const story = (ctx: { globals: { theme?: string } }): null => {
+      if (ctx.globals.theme !== undefined) seen.push(ctx.globals.theme);
+      return null;
+    };
+    themeDecorator(story, { globals: { theme: 'swiss' } });
+    expect(seen).toEqual(['swiss']);
+  });
+});

--- a/src/stories/_decorators/theme.ts
+++ b/src/stories/_decorators/theme.ts
@@ -1,0 +1,54 @@
+/**
+ * Storybook decorator that writes the toolbar's theme / preset / density
+ * globals onto the document root so CSS rules keyed on `[data-theme]`,
+ * `[data-preset]`, `[data-density]` actually apply.
+ *
+ * Storybook's HTML framework calls the decorator with `(storyFn, context)`;
+ * we only read `context.globals`. The decorator returns the rendered DOM
+ * unchanged.
+ *
+ * SB-16 (#54) folds `[data-theme]` into `[data-preset]` later. Until then,
+ * both attributes are written so the live app's CSS (which still keys on
+ * `[data-theme]`) and the design system's CSS (`[data-preset]`/`[data-density]`)
+ * both repaint together.
+ */
+
+interface ThemeGlobals {
+  readonly theme?: string;
+  readonly preset?: string;
+  readonly density?: string;
+}
+
+/**
+ * Apply the toolbar globals to a root element. Exported separately from the
+ * Storybook-shaped decorator so unit tests can drive it without pulling in
+ * Storybook's runtime.
+ */
+export function applyThemeGlobals(globals: ThemeGlobals, root: HTMLElement): void {
+  if (typeof globals.theme === 'string' && globals.theme.length > 0) {
+    root.dataset.theme = globals.theme;
+  }
+  if (typeof globals.preset === 'string' && globals.preset.length > 0) {
+    root.dataset.preset = globals.preset;
+  }
+  if (typeof globals.density === 'string' && globals.density.length > 0) {
+    root.dataset.density = globals.density;
+  }
+}
+
+interface DecoratorContext {
+  readonly globals: ThemeGlobals;
+}
+
+type StoryFn = (context: DecoratorContext) => unknown;
+
+/**
+ * Storybook HTML decorator. Reads `context.globals` and applies them to
+ * `document.documentElement` before delegating to the wrapped story.
+ */
+export function themeDecorator(storyFn: StoryFn, context: DecoratorContext): unknown {
+  if (typeof document !== 'undefined') {
+    applyThemeGlobals(context.globals, document.documentElement);
+  }
+  return storyFn(context);
+}

--- a/src/stories/design-showcase.stories.ts
+++ b/src/stories/design-showcase.stories.ts
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from '@storybook/html';
+
+interface StoryArgs {
+  path: string;
+  title: string;
+}
+
+interface StoryContext {
+  globals: {
+    theme?: string;
+    density?: string;
+  };
+}
+
+const DESIGN_ROOT = '/design-showcase';
+const THEMES = ['mono', 'editorial', 'grid', 'aurora', 'clean'] as const;
+const DENSITIES = ['default', 'compact'] as const;
+
+const screens = [
+  { id: 'home', title: 'Home', path: 'index.html' },
+  { id: 'hash', title: 'Hash text', path: 'tools/hash.html' },
+  { id: 'encrypt', title: 'Encrypt / decrypt', path: 'tools/encrypt.html' },
+  { id: 'jwt', title: 'JWT parser', path: 'tools/jwt.html' },
+  { id: 'bcrypt', title: 'Bcrypt hash', path: 'tools/bcrypt.html' },
+  { id: 'base64', title: 'Base64 string', path: 'tools/base64.html' },
+  { id: 'jsonYaml', title: 'JSON to YAML', path: 'tools/json-yaml.html' },
+  { id: 'color', title: 'Color converter', path: 'tools/color.html' },
+  { id: 'case', title: 'Case converter', path: 'tools/case.html' },
+  { id: 'urlEncode', title: 'URL encode/decode', path: 'tools/url-encode.html' },
+  { id: 'htmlEscape', title: 'HTML escape', path: 'tools/html-escape.html' },
+  { id: 'userAgent', title: 'User-agent parser', path: 'tools/user-agent.html' },
+  { id: 'qr', title: 'QR code generator', path: 'tools/qr.html' },
+  { id: 'ascii', title: 'ASCII art', path: 'tools/ascii.html' },
+  { id: 'regex', title: 'Regex tester', path: 'tools/regex.html' },
+  { id: 'formatJson', title: 'JSON formatter', path: 'tools/format-json.html' },
+  { id: 'diff', title: 'Text diff', path: 'tools/diff.html' },
+  { id: 'mathEval', title: 'Math evaluator', path: 'tools/math-eval.html' },
+  { id: 'baseConv', title: 'Base converter', path: 'tools/base-conv.html' },
+  { id: 'chmod', title: 'chmod calculator', path: 'tools/chmod.html' },
+  { id: 'benchmark', title: 'Benchmark', path: 'tools/benchmark.html' },
+  { id: 'lorem', title: 'Lorem ipsum', path: 'tools/lorem.html' },
+  { id: 'wordcount', title: 'Word counter', path: 'tools/wordcount.html' },
+  { id: 'uuid', title: 'UUID generator', path: 'tools/uuid.html' },
+  { id: 'ulid', title: 'ULID generator', path: 'tools/ulid.html' },
+  { id: 'password', title: 'Password generator', path: 'tools/password.html' },
+] as const;
+
+const meta = {
+  title: 'Design Screens/Tools',
+  render: (args: StoryArgs, context: StoryContext) => renderScreen(args, context),
+  argTypes: {
+    path: { table: { disable: true } },
+    title: { table: { disable: true } },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Stories render the HTML pages extracted from `IT Tools (2).zip`. Use the toolbar theme dropdown and viewport selector for cross-browser visual review.',
+      },
+    },
+  },
+} satisfies Meta<StoryArgs>;
+
+export default meta;
+type Story = StoryObj<StoryArgs>;
+
+export const VisualTestingGuide: Story = {
+  name: 'Visual Testing Guide',
+  args: { title: 'Visual Testing Guide', path: '' },
+  render: () => renderGuide(),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export const Home: Story = {
+  args: { title: 'Home', path: 'index.html' },
+};
+
+export const HashText: Story = { args: screens[1] };
+export const EncryptDecrypt: Story = { args: screens[2] };
+export const JwtParser: Story = { args: screens[3] };
+export const BcryptHash: Story = { args: screens[4] };
+export const Base64String: Story = { args: screens[5] };
+export const JsonYaml: Story = { args: screens[6] };
+export const ColorConverter: Story = { args: screens[7] };
+export const CaseConverter: Story = { args: screens[8] };
+export const UrlEncodeDecode: Story = { args: screens[9] };
+export const HtmlEscape: Story = { args: screens[10] };
+export const UserAgentParser: Story = { args: screens[11] };
+export const QrCodeGenerator: Story = { args: screens[12] };
+export const AsciiArt: Story = { args: screens[13] };
+export const RegexTester: Story = { args: screens[14] };
+export const JsonFormatter: Story = { args: screens[15] };
+export const TextDiff: Story = { args: screens[16] };
+export const MathEvaluator: Story = { args: screens[17] };
+export const BaseConverter: Story = { args: screens[18] };
+export const ChmodCalculator: Story = { args: screens[19] };
+export const Benchmark: Story = { args: screens[20] };
+export const LoremIpsum: Story = { args: screens[21] };
+export const WordCounter: Story = { args: screens[22] };
+export const UuidGenerator: Story = { args: screens[23] };
+export const UlidGenerator: Story = { args: screens[24] };
+export const PasswordGenerator: Story = { args: screens[25] };
+
+function renderScreen(args: StoryArgs, context: StoryContext): HTMLElement {
+  const theme = getTheme(context.globals.theme);
+  const density = getDensity(context.globals.density);
+  const wrap = document.createElement('div');
+  wrap.style.height = '100vh';
+  wrap.style.background = '#111';
+
+  const iframe = document.createElement('iframe');
+  iframe.title = args.title;
+  iframe.src = 'about:blank';
+  iframe.style.display = 'block';
+  iframe.style.width = '100%';
+  iframe.style.height = '100%';
+  iframe.style.border = '0';
+  iframe.dataset.visualTest = args.title;
+
+  wrap.append(iframe);
+
+  requestAnimationFrame(() => {
+    const win = iframe.contentWindow;
+    if (win) {
+      win.localStorage.setItem('it.theme', JSON.stringify(theme));
+      win.localStorage.setItem('it.density', JSON.stringify(density));
+    }
+    iframe.src = `${DESIGN_ROOT}/${args.path}`;
+  });
+
+  return wrap;
+}
+
+function renderGuide(): HTMLElement {
+  const el = document.createElement('article');
+  el.style.maxWidth = '920px';
+  el.style.margin = '0 auto';
+  el.style.padding = '32px';
+  el.style.font = '14px/1.55 system-ui, sans-serif';
+  el.style.color = '#111827';
+  el.innerHTML = `
+    <h1>Visual testing guide</h1>
+    <p>Use these stories as the source of truth for the extracted zip screens.</p>
+    <h2>Coverage matrix</h2>
+    <ul>
+      <li>Browsers: Chromium, Firefox, WebKit.</li>
+      <li>Viewports: 390x844, 768x1024, 1440x900, 1920x1080.</li>
+      <li>Themes: ${THEMES.join(', ')}. Densities: ${DENSITIES.join(', ')}.</li>
+      <li>States: default load, focused input, hoverable cards/buttons, sidebar collapsed where available.</li>
+    </ul>
+    <h2>Pixel-perfect rules</h2>
+    <ul>
+      <li>Freeze time, animation, random data, and remote fonts before taking baselines.</li>
+      <li>Capture full page and key component crops; use a 0.1% diff budget for layout and 0.5% for anti-aliasing-heavy text.</li>
+      <li>Fail on overlap, clipped text, unexpected scrollbars, missing icons, blank panels, and shifted navigation.</li>
+      <li>Keep one baseline per browser, viewport, and theme. Do not share Chromium baselines with WebKit or Firefox.</li>
+    </ul>
+    <h2>Suggested Playwright command</h2>
+    <pre><code>pnpm storybook
+pnpm playwright test --project=chromium --project=firefox --project=webkit</code></pre>
+  `;
+  return el;
+}
+
+function getTheme(value: string | undefined): (typeof THEMES)[number] {
+  return THEMES.includes(value as (typeof THEMES)[number])
+    ? (value as (typeof THEMES)[number])
+    : 'mono';
+}
+
+function getDensity(value: string | undefined): (typeof DENSITIES)[number] {
+  return DENSITIES.includes(value as (typeof DENSITIES)[number])
+    ? (value as (typeof DENSITIES)[number])
+    : 'default';
+}

--- a/src/stories/developer-tools-design-system.stories.ts
+++ b/src/stories/developer-tools-design-system.stories.ts
@@ -1,0 +1,587 @@
+import type { Meta, StoryObj } from '@storybook/html';
+
+interface StoryContext {
+  globals: {
+    theme?: string;
+    preset?: string;
+    density?: string;
+  };
+}
+
+const THEMES = ['mono', 'editorial', 'grid', 'aurora', 'clean'] as const;
+const PRESETS = ['linear', 'vercel', 'paper', 'swiss', 'aurora', 'clean', 'matrix'] as const;
+const DENSITIES = ['default', 'compact'] as const;
+
+const TOKEN_GROUPS = {
+  color: [
+    '--bg',
+    '--bg-2',
+    '--bg-3',
+    '--panel',
+    '--fg',
+    '--fg-dim',
+    '--fg-faint',
+    '--accent',
+    '--accent-2',
+    '--border',
+    '--border-2',
+  ],
+  semantic: [
+    '--dt-success',
+    '--dt-success-bg',
+    '--dt-warning',
+    '--dt-warning-bg',
+    '--dt-danger',
+    '--dt-danger-bg',
+    '--dt-focus-ring',
+  ],
+  shapeType: [
+    '--radius',
+    '--radius-sm',
+    '--dt-control-sm',
+    '--dt-control-md',
+    '--dt-control-lg',
+    '--font-body',
+    '--font-head',
+    '--font-mono',
+  ],
+} as const;
+
+const meta = {
+  title: 'Developer Tools Design System',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A governed Storybook layer for the developer-tools UI extracted from `IT Tools (2).zip`: tokens, presets, reusable primitives, states, responsive app frame, and visual verification rules.',
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj;
+
+export const Foundations: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Foundations');
+    root.append(tokenSection('Color Tokens', TOKEN_GROUPS.color));
+    root.append(tokenSection('Semantic Tokens', TOKEN_GROUPS.semantic));
+    root.append(tokenSection('Shape + Type Tokens', TOKEN_GROUPS.shapeType));
+    root.append(typeScale());
+    return root;
+  },
+};
+
+export const Presets: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Presets');
+    const grid = document.createElement('section');
+    grid.className = 'dt-grid';
+    grid.innerHTML = PRESETS.map((preset) => presetCard(preset)).join('');
+    root.append(grid);
+    return root;
+  },
+};
+
+export const Buttons: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Buttons');
+    root.append(section('Core Buttons', buttonsMarkup()));
+    root.append(section('Icon + Destructive', iconButtonMarkup()));
+    return root;
+  },
+};
+
+export const Forms: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Forms');
+    root.append(section('Inputs', formsMarkup()));
+    root.append(section('Validation', validationMarkup()));
+    return root;
+  },
+};
+
+export const ToolCards: Story = {
+  name: 'Tool Cards',
+  render: (_args, context) => {
+    const root = shell(context, 'Tool Cards');
+    const panel = document.createElement('section');
+    panel.className = 'dt-grid';
+    panel.innerHTML = `
+      ${toolCard('Hash text', 'MD5, SHA-1, SHA-256, SHA-512 in your browser.', '##', 'a3f2b9c1...', 'mono', true)}
+      ${toolCard('Color converter', 'HEX, RGB, HSL and OKLCH all at once.', '**', '#6366f1', 'swatch')}
+      ${toolCard('Regex tester', 'Live-match patterns against test strings.', '/x/', '/^[a-z]+$/', 'chip')}
+      ${toolCard('Password generator', 'Strong, random passwords with options.', '***', '32 chars', 'chip')}
+    `;
+    root.append(panel);
+    return root;
+  },
+};
+
+export const Navigation: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Navigation');
+    const grid = document.createElement('div');
+    grid.className = 'dt-grid';
+    grid.append(section('Sidebar List', navMarkup()), section('Search + Command', commandMarkup()));
+    root.append(grid);
+    return root;
+  },
+};
+
+export const Results: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Results');
+    const grid = document.createElement('div');
+    grid.className = 'dt-grid';
+    grid.append(section('Key-value Rows', kvMarkup()), section('Stats + Output', resultMarkup()));
+    root.append(grid);
+    return root;
+  },
+};
+
+export const AppFrame: Story = {
+  name: 'App Frame',
+  render: (_args, context) => {
+    setupSystem(context);
+    const root = document.createElement('div');
+    root.className = 'app dt-story-app-frame';
+    root.innerHTML = `
+      <aside class="sidebar">
+        <div class="sidebar-head">
+          <a class="brand" href="#"><span class="brand-mark">IT</span><span class="brand-text">IT&nbsp;Tools</span></a>
+          <button class="sidebar-collapse" aria-label="Collapse sidebar">⌁</button>
+        </div>
+        <button class="search-btn"><span class="search-icon">⌕</span><span class="search-label">Search tools...</span><span class="kbd">⌘K</span></button>
+        <nav class="sidebar-nav-scroll">
+          <div class="nav-section">
+            <div class="nav-section-title">Converter</div>
+            ${zipNavItem('Base64 string', true)}
+            ${zipNavItem('JSON to YAML')}
+            ${zipNavItem('Color converter')}
+          </div>
+          <div class="nav-section">
+            <div class="nav-section-title">Development</div>
+            ${zipNavItem('Regex tester')}
+            ${zipNavItem('JSON formatter')}
+            ${zipNavItem('Text diff')}
+          </div>
+        </nav>
+        <div class="sidebar-foot">
+          <div class="sidebar-foot-info"><span class="dot"></span><span class="t">v26.5 · 26 tools · local</span></div>
+          <div class="sidebar-credit">All processing runs in your browser.</div>
+        </div>
+      </aside>
+      <main class="main">
+        <div class="topbar">
+          <button class="icon-btn sidebar-toggle" aria-label="Toggle sidebar">☰</button>
+          <div class="crumbs">Home / Converter / Base64 string</div>
+          <div class="topbar-actions">
+            <button class="icon-btn" aria-label="Search">⌕</button>
+            <button class="icon-btn" aria-label="Theme">◐</button>
+          </div>
+        </div>
+        <h1 class="page-title">Base64 string</h1>
+        <p class="page-sub">Encode and decode UTF-8 text to and from Base64.</p>
+        ${toolBodyMarkup()}
+      </main>
+    `;
+    return root;
+  },
+};
+
+export const Verification: Story = {
+  render: (_args, context) => {
+    const root = shell(context, 'Visual Verification');
+    root.append(section('Pixel-perfect Guidelines', verificationMarkup()));
+    return root;
+  },
+};
+
+function shell(context: StoryContext, title: string): HTMLElement {
+  const settings = setupSystem(context);
+  const root = document.createElement('main');
+  root.className = 'dt-story-shell';
+  root.innerHTML = `
+    <header class="dt-story-header">
+      <div>
+        <div class="dt-label">Developer tools design system</div>
+        <h1 class="page-title">${title}</h1>
+        <p class="page-sub">Theme: ${settings.theme} · Preset: ${settings.preset} · Density: ${settings.density}</p>
+      </div>
+      <span class="dt-status" data-tone="success">storybook source</span>
+    </header>
+  `;
+  return root;
+}
+
+function setupSystem(context: StoryContext): {
+  theme: (typeof THEMES)[number];
+  preset: (typeof PRESETS)[number];
+  density: (typeof DENSITIES)[number];
+} {
+  ensureAssets();
+  const theme = getTheme(context.globals.theme);
+  const preset = getPreset(context.globals.preset);
+  const density = getDensity(context.globals.density);
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.setAttribute('data-preset', preset);
+  document.documentElement.setAttribute('data-density', density);
+  document.documentElement.setAttribute('data-card', preset === 'aurora' ? 'glass' : 'subtle');
+  document.documentElement.setAttribute(
+    'data-btn',
+    preset === 'swiss' || preset === 'matrix' ? 'square' : 'rounded',
+  );
+  document.body.style.margin = '0';
+  return { theme, preset, density };
+}
+
+function ensureAssets(): void {
+  addLink('/design-showcase/themes.css', 'design-showcase-css');
+  addLink('/design-showcase/system-tokens.css', 'design-system-tokens-css');
+  addLink('/design-showcase/system-components.css', 'design-system-components-css');
+
+  if (!document.querySelector('style[data-design-system-story-css]')) {
+    const style = document.createElement('style');
+    style.dataset.designSystemStoryCss = 'true';
+    style.textContent = `
+      .dt-story-shell { min-height: 100vh; padding: var(--dt-space-7); background: var(--bg); color: var(--fg); font-family: var(--font-body); }
+      .dt-story-header { display: flex; align-items: start; justify-content: space-between; gap: var(--dt-space-6); margin-bottom: var(--dt-space-6); }
+      .dt-story-section { margin-bottom: var(--dt-space-6); }
+      .dt-story-section-title { margin: 0 0 var(--dt-space-3); color: var(--dt-text); font: 650 var(--dt-text-lg)/1.2 var(--font-head); }
+      .dt-token-table { width: 100%; border-collapse: collapse; overflow: hidden; border: 1px solid var(--dt-line); border-radius: var(--radius); }
+      .dt-token-table th, .dt-token-table td { padding: 10px 12px; border-bottom: 1px solid var(--dt-line); text-align: left; font-size: 12px; }
+      .dt-token-table code { font-family: var(--font-mono); }
+      .dt-swatch { width: 34px; height: 22px; border: 1px solid var(--dt-line-strong); border-radius: 5px; display: inline-block; vertical-align: middle; }
+      .dt-preset-card { min-height: 170px; }
+      .dt-preset-swatches { display: flex; gap: 4px; margin-top: var(--dt-space-4); }
+      .dt-preset-swatches span { width: 28px; height: 18px; border: 1px solid var(--dt-line); border-radius: 4px; }
+      .dt-type-demo { display: grid; gap: var(--dt-space-3); }
+      .dt-story-app-frame { min-height: 100vh; color: var(--fg); background: var(--bg); font-family: var(--font-body); }
+      .dt-copy { max-width: 900px; }
+      .dt-copy h3 { margin: 18px 0 6px; font-size: 17px; }
+      .dt-copy p { color: var(--dt-text-muted); }
+      .dt-copy pre { white-space: pre-wrap; background: var(--dt-surface-muted); border: 1px solid var(--dt-line); border-radius: var(--radius-sm); padding: var(--dt-space-4); }
+      @media (max-width: 860px) { .dt-story-shell { padding: var(--dt-space-5); } .dt-story-header { display: grid; } }
+    `;
+    document.head.append(style);
+  }
+}
+
+function addLink(href: string, key: string): void {
+  if (document.querySelector(`link[data-${key}]`)) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  link.setAttribute(`data-${key}`, 'true');
+  document.head.append(link);
+}
+
+function section(title: string, markup: string): HTMLElement {
+  const node = document.createElement('section');
+  node.className = 'dt-panel dt-story-section';
+  node.innerHTML = `<h2 class="dt-story-section-title">${title}</h2>${markup}`;
+  return node;
+}
+
+function tokenSection(title: string, tokens: readonly string[]): HTMLElement {
+  const node = document.createElement('section');
+  node.className = 'dt-story-section';
+  const styles = getComputedStyle(document.documentElement);
+  node.innerHTML = `
+    <h2 class="dt-story-section-title">${title}</h2>
+    <table class="dt-token-table">
+      <thead><tr><th>Token</th><th>Value</th><th>Preview</th></tr></thead>
+      <tbody>
+        ${tokens
+          .map((token) => {
+            const value = styles.getPropertyValue(token).trim();
+            const canSwatch =
+              token.includes('bg') ||
+              token.includes('fg') ||
+              token.includes('accent') ||
+              token.includes('border') ||
+              token.includes('success') ||
+              token.includes('warning') ||
+              token.includes('danger');
+            return `<tr><td><code>${token}</code></td><td><code>${value}</code></td><td>${canSwatch ? `<span class="dt-swatch" style="background:${value}"></span>` : ''}</td></tr>`;
+          })
+          .join('')}
+      </tbody>
+    </table>
+  `;
+  return node;
+}
+
+function typeScale(): HTMLElement {
+  return section(
+    'Typography',
+    `
+      <div class="dt-type-demo">
+        <h1 class="page-title">Page title / tool name</h1>
+        <p class="page-sub">Page subtitle explains the selected utility in one concise sentence.</p>
+        <p>Body copy stays compact because this product is workflow-heavy and scan-first.</p>
+        <code>Monospace output, IDs, hashes, commands, and parsed values use var(--font-mono).</code>
+      </div>
+    `,
+  );
+}
+
+function presetCard(preset: (typeof PRESETS)[number]): string {
+  const swatches: Record<(typeof PRESETS)[number], string[]> = {
+    linear: ['#0a0a0a', '#181818', '#6366f1'],
+    vercel: ['#000000', '#0a0a0a', '#ffffff'],
+    paper: ['#faf8f4', '#ffffff', '#b45309'],
+    swiss: ['#fafafa', '#0a0a0a', '#dc2626'],
+    aurora: ['#07080f', '#8b5cf6', '#06b6d4'],
+    clean: ['#f1f5f9', '#ffffff', '#18a058'],
+    matrix: ['#000000', '#003311', '#00ff41'],
+  };
+  return `
+    <article class="dt-panel dt-preset-card" data-preset-card="${preset}">
+      <div class="dt-label">${preset}</div>
+      <h3 class="dt-tool-card__name">${presetLabel(preset)}</h3>
+      <p class="dt-tool-card__desc">${presetNote(preset)}</p>
+      <div class="dt-preset-swatches">${swatches[preset].map((color) => `<span style="background:${color}"></span>`).join('')}</div>
+    </article>
+  `;
+}
+
+function buttonsMarkup(): string {
+  return `
+    <div class="dt-cluster">
+      <button class="dt-button">Secondary</button>
+      <button class="dt-button" data-variant="primary">Primary</button>
+      <button class="dt-button" aria-disabled="true">Disabled</button>
+      <button class="dt-button"><span aria-hidden="true">↻</span> Regenerate</button>
+      <button class="dt-button" data-variant="primary"><span aria-hidden="true">⧉</span> Copy value</button>
+    </div>
+  `;
+}
+
+function iconButtonMarkup(): string {
+  return `
+    <div class="dt-cluster">
+      <button class="dt-button dt-icon-button" aria-label="Search">⌕</button>
+      <button class="dt-button dt-icon-button" aria-label="Favorite">★</button>
+      <button class="dt-button dt-icon-button" aria-label="Copy">⧉</button>
+      <button class="dt-button" data-variant="danger">Clear history</button>
+      <span class="dt-status" data-tone="success">local only</span>
+      <span class="dt-status" data-tone="danger">invalid input</span>
+    </div>
+  `;
+}
+
+function formsMarkup(): string {
+  return `
+    <div class="dt-form-grid">
+      <label class="dt-field"><span>Text input</span><input class="dt-input" value="developer-tools" /></label>
+      <label class="dt-field"><span>Number</span><input class="dt-input" type="number" value="128" /></label>
+      <label class="dt-field"><span>Select</span><select class="dt-select"><option>Base64</option><option>HEX</option><option>URL-safe</option></select></label>
+    </div>
+    <div class="dt-stack" style="margin-top: var(--dt-space-4);">
+      <label class="dt-field"><span>Textarea</span><textarea class="dt-textarea">The quick brown fox jumps over the lazy dog.</textarea></label>
+    </div>
+  `;
+}
+
+function validationMarkup(): string {
+  return `
+    <div class="dt-form-grid">
+      <label class="dt-field">
+        <span>Focused-valid pattern</span>
+        <input class="dt-input" value="^[a-z]+$" />
+        <span class="dt-help">Use semantic status text close to the field.</span>
+      </label>
+      <label class="dt-field">
+        <span>Error state</span>
+        <input class="dt-input" aria-invalid="true" value="{ broken json" />
+        <span class="dt-help" style="color: var(--dt-danger);">Expected valid JSON object.</span>
+      </label>
+    </div>
+  `;
+}
+
+function toolCard(
+  name: string,
+  desc: string,
+  icon: string,
+  preview: string,
+  previewType: 'mono' | 'swatch' | 'chip',
+  favorite = false,
+): string {
+  const previewMarkup =
+    previewType === 'swatch'
+      ? `<span class="dt-preview"><span class="dt-preview__swatch" style="background:${preview}"></span><code>${preview}</code></span>`
+      : `<span class="dt-preview"><code>${preview}</code></span>`;
+  return `
+    <a class="dt-tool-card" href="#" data-favorite="${favorite ? 'true' : 'false'}">
+      <div class="dt-tool-card__icon">${icon}</div>
+      <h3 class="dt-tool-card__name">${name}</h3>
+      <p class="dt-tool-card__desc">${desc}</p>
+      ${previewMarkup}
+      <button class="dt-tool-card__favorite" aria-label="${favorite ? 'Unfavorite' : 'Favorite'}">${favorite ? '★' : '☆'}</button>
+    </a>
+  `;
+}
+
+function navMarkup(): string {
+  return `
+    <div class="dt-label">Favorites</div>
+    <div class="dt-nav-list">
+      ${systemNavItem('UUID generator', true)}
+      ${systemNavItem('Hash text')}
+      ${systemNavItem('Regex tester')}
+      ${systemNavItem('JSON formatter')}
+    </div>
+  `;
+}
+
+function commandMarkup(): string {
+  return `
+    <div class="dt-stack">
+      <button class="search-btn"><span class="search-icon">⌕</span><span class="search-label">Search tools...</span><span class="kbd">⌘K</span></button>
+      <div class="dt-output">Command palette should preserve focus order, active item styling, category labels, and keyboard navigation across every theme.</div>
+    </div>
+  `;
+}
+
+function systemNavItem(label: string, active = false): string {
+  return `
+    <a class="dt-nav-item" href="#" data-active="${active ? 'true' : 'false'}">
+      <span class="dt-nav-item__icon">⌘</span>
+      <span class="dt-nav-item__label">${label}</span>
+    </a>
+  `;
+}
+
+function zipNavItem(label: string, active = false): string {
+  return `
+    <a class="nav-item ${active ? 'active starred' : ''}" href="#" data-tip="${label}">
+      <span class="icon">⌘</span>
+      <span class="label">${label}</span>
+      <button class="star" aria-label="Favorite">${active ? '★' : '☆'}</button>
+    </a>
+  `;
+}
+
+function kvMarkup(): string {
+  return `
+    <div class="dt-kv-list">
+      ${kvRow('HEX', '#8B5CF6')}
+      ${kvRow('RGB', 'rgb(139, 92, 246)')}
+      ${kvRow('HSL', 'hsl(262 83.3% 66.3%)')}
+      ${kvRow('OKLCH', 'oklch(62.3% 0.214 292.4)')}
+    </div>
+  `;
+}
+
+function kvRow(key: string, value: string): string {
+  return `
+    <div class="dt-kv-row">
+      <span class="dt-kv-row__key">${key}</span>
+      <span class="dt-kv-row__value">${value}</span>
+      <button class="dt-button dt-icon-button" aria-label="Copy ${key}">⧉</button>
+    </div>
+  `;
+}
+
+function resultMarkup(): string {
+  return `
+    <div class="dt-stack">
+      <div class="dt-stat-grid">
+        <div class="dt-stat"><div class="dt-stat__label">Words</div><div class="dt-stat__value">128</div></div>
+        <div class="dt-stat"><div class="dt-stat__label">Characters</div><div class="dt-stat__value">742</div></div>
+        <div class="dt-stat"><div class="dt-stat__label">Read time</div><div class="dt-stat__value">1m</div></div>
+      </div>
+      <div class="dt-output">f47ac10b-58cc-4372-a567-0e02b2c3d479</div>
+      <div class="dt-color-preview" style="background:#8b5cf6;">#8B5CF6</div>
+    </div>
+  `;
+}
+
+function toolBodyMarkup(): string {
+  return `
+    <div class="tool-page">
+      <div class="field-row two">
+        <div class="panel" data-label="PLAIN">
+          <div class="panel-label">Plain text</div>
+          <textarea>Hello, world</textarea>
+        </div>
+        <div class="panel" data-label="BASE64">
+          <div class="panel-label">Base64</div>
+          <textarea>SGVsbG8sIHdvcmxk</textarea>
+        </div>
+      </div>
+      <div class="row">
+        <button class="btn">URL-safe</button>
+        <button class="btn">Swap</button>
+        <button class="btn primary">Copy Base64</button>
+      </div>
+      <div class="output">Output preview / status text</div>
+    </div>
+  `;
+}
+
+function verificationMarkup(): string {
+  return `
+    <div class="dt-copy">
+      <h3>Coverage matrix</h3>
+      <p>Baseline Chromium, Firefox, and WebKit separately. Capture 390x844, 768x1024, 1440x900, and 1920x1080 for every theme and preset.</p>
+      <h3>Hard failures</h3>
+      <p>Fail on clipped text, overlapping controls, missing icons, unexpected scrollbars, blank panels, broken focus rings, and component layout shifts between states.</p>
+      <h3>Diff budgets</h3>
+      <p>Use 0.1% max diff for component crops and 0.5% for full pages with dense text. Keep browser-specific baselines because font rasterization differs.</p>
+      <h3>Stability</h3>
+      <pre><code>await page.emulateMedia({ reducedMotion: 'reduce' });
+await page.evaluate(() => document.fonts.ready);
+await expect(page).toHaveScreenshot({ maxDiffPixelRatio: 0.001 });</code></pre>
+    </div>
+  `;
+}
+
+function presetLabel(preset: (typeof PRESETS)[number]): string {
+  const labels: Record<(typeof PRESETS)[number], string> = {
+    linear: 'Linear-grade dark workbench',
+    vercel: 'Black, Geist, sharper edges',
+    paper: 'Editorial serif surface',
+    swiss: 'Monochrome grid system',
+    aurora: 'Glass and gradient dark',
+    clean: 'Friendly structured light',
+    matrix: 'Green-on-black terminal',
+  };
+  return labels[preset];
+}
+
+function presetNote(preset: (typeof PRESETS)[number]): string {
+  const notes: Record<(typeof PRESETS)[number], string> = {
+    linear: 'Default production recommendation: dense, quiet, and high contrast.',
+    vercel: 'Useful for brand-neutral dark mode with minimal chroma.',
+    paper: 'Best for editorial or documentation-heavy variants.',
+    swiss: 'Best for strict layouts, sharp borders, and audit-friendly screens.',
+    aurora: 'Use sparingly for expressive previews or marketing-adjacent surfaces.',
+    clean: 'Best light-mode candidate for everyday utility workflows.',
+    matrix: 'Novelty preset, useful as an accessibility stress case for high chroma.',
+  };
+  return notes[preset];
+}
+
+function getTheme(value: string | undefined): (typeof THEMES)[number] {
+  return THEMES.includes(value as (typeof THEMES)[number])
+    ? (value as (typeof THEMES)[number])
+    : 'mono';
+}
+
+function getPreset(value: string | undefined): (typeof PRESETS)[number] {
+  return PRESETS.includes(value as (typeof PRESETS)[number])
+    ? (value as (typeof PRESETS)[number])
+    : 'linear';
+}
+
+function getDensity(value: string | undefined): (typeof DENSITIES)[number] {
+  return DENSITIES.includes(value as (typeof DENSITIES)[number])
+    ? (value as (typeof DENSITIES)[number])
+    : 'default';
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       'tools/**',
       'design/**',
       '.playwright-mcp/**',
+      '.claude/**',
       'tests/e2e/**',
     ],
     coverage: {


### PR DESCRIPTION
## Summary

Wires the Storybook toolbar globals (theme / preset / density) onto the document root so switching them actually changes how stories render.

**Stacked on:** #71 (Day-A) — base set to \`feat/sb-day-a\`. After #71 merges, this PR's base will rebase to \`master\` automatically.

Closes #42 (SB-03). Refs #70 (Storybook-first, live-app-after policy).

## What changed

### Decorator
- New \`src/stories/_decorators/theme.ts\`:
  - \`applyThemeGlobals(globals, root)\` — pure function, sets \`dataset.theme\`, \`dataset.preset\`, \`dataset.density\`. Skips empty/undefined values to avoid clobbering.
  - \`themeDecorator(storyFn, ctx)\` — Storybook-shaped wrapper that calls \`applyThemeGlobals\` against \`document.documentElement\`.
- New \`src/stories/_decorators/theme.test.ts\` — 5 tests cover dataset writes, empty-value skipping, undefined-value skipping, decorator invocation, and context pass-through.

### Preview config
- \`.storybook/preview.ts\` decorators array now includes \`themeDecorator\`.
- Replaced the design-only theme list (\`mono / editorial / grid / aurora / clean\`) with the live app's 7 themes from \`src/lib/theme.ts\`:
  \`clean / linear / vercel / paper / swiss / aurora / matrix\`.
- Default theme switched from invalid \`mono\` (no such theme exists in CSS) to \`clean\`.
- Both \`[data-theme]\` and \`[data-preset]\` written until #54 (SB-16) unifies on \`[data-preset]\` + \`[data-density]\`.

## Acceptance criteria (EARS)

- [x] **R5.1** — Toggling theme/preset/density visibly changes the active story; data attrs update within one frame.
- [x] **R5.2** — Globals persist across navigation (Storybook handles this; decorator re-applies on every render).
- [ ] R5.3 — addon-a11y panel (#56, separate ticket).
- [ ] R5.4 — \`a11y-exempt\` banner (#56 + #67, separate tickets).

## Verification

- \`pnpm typecheck\` — clean.
- \`pnpm test\` — 537 tests pass (was 532, +5 new).
- \`pnpm lint\` — 0 errors.
- \`pnpm format:check\` — clean.
- \`pnpm build-storybook\` — clean build, 1.46s preview build.
- \`pnpm build\` — live app builds.

## Test plan

- [ ] Open Storybook → switch theme dropdown across all 7 values → confirm \`<html data-theme="...">\` updates and visible style changes apply.
- [ ] Switch density between \`default\` and \`compact\` → confirm \`<html data-density="...">\` updates (no visual change yet — design-system CSS picks this up only after SB-16).