### PR TITLE
feat(ui): variants helper + new primitives + layout + data displays (SB-14)

### DIFF
--- a/src/stories/00-foundations/data-display.stories.ts
+++ b/src/stories/00-foundations/data-display.stories.ts
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import '../_styles/foundations.css';
+import { kvRow } from '../../ui/data-display/kv-row';
+import { kvList } from '../../ui/data-display/kv-list';
+import { output } from '../../ui/data-display/output';
+import { preview } from '../../ui/data-display/preview';
+
+const meta: Meta = {
+  title: 'Foundations / Data display',
+};
+
+export default meta;
+
+function host(child: HTMLElement): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'dt-foundation-host';
+  root.style.padding = '24px';
+  root.style.maxWidth = '720px';
+  root.appendChild(child);
+  return root;
+}
+
+export const KvRowDefault: StoryObj = {
+  name: 'KV row / Default',
+  render: () => host(kvRow({ key: 'Algorithm', value: 'AES-256-GCM' }).el),
+};
+
+export const KvRowWithCopy: StoryObj = {
+  name: 'KV row / With copy',
+  render: () =>
+    host(
+      kvRow({
+        key: 'Token',
+        value: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4eHgifQ.signature',
+        mono: true,
+        copyable: true,
+      }).el,
+    ),
+};
+
+export const KvListJwt: StoryObj = {
+  name: 'KV list / JWT decoded',
+  render: () =>
+    host(
+      kvList({
+        entries: [
+          { key: 'alg', value: 'HS256', mono: true, copyable: true },
+          { key: 'typ', value: 'JWT', mono: true },
+          { key: 'sub', value: '1234567890', mono: true, copyable: true },
+          { key: 'iat', value: '1516239022', mono: true },
+        ],
+      }).el,
+    ),
+};
+
+export const OutputJson: StoryObj = {
+  name: 'Output / JSON',
+  render: () =>
+    host(
+      output({
+        language: 'json',
+        content: JSON.stringify(
+          { name: 'developer-tools', version: '1.2.0', shipped: 42 },
+          null,
+          2,
+        ),
+      }),
+    ),
+};
+
+export const OutputPlain: StoryObj = {
+  name: 'Output / Plain',
+  render: () => host(output({ content: 'one\ntwo\nthree\nfour' })),
+};
+
+export const PreviewWithCaption: StoryObj = {
+  name: 'Preview / With caption',
+  render: () => {
+    const button = document.createElement('button');
+    button.textContent = 'Click me';
+    button.style.padding = '8px 16px';
+    button.style.background = '#111';
+    button.style.color = '#fff';
+    button.style.border = '0';
+    button.style.borderRadius = '6px';
+    return host(preview({ caption: 'Live preview', content: button }));
+  },
+};

--- a/src/stories/00-foundations/layout.stories.ts
+++ b/src/stories/00-foundations/layout.stories.ts
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import '../_styles/foundations.css';
+import { grid } from '../../ui/layout/grid';
+import { formGrid } from '../../ui/layout/form-grid';
+import { push } from '../../ui/layout/push';
+import { grow } from '../../ui/layout/grow';
+
+const meta: Meta = {
+  title: 'Foundations / Layout',
+};
+
+export default meta;
+
+function host(child: HTMLElement): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'dt-foundation-host';
+  root.style.padding = '24px';
+  root.appendChild(child);
+  return root;
+}
+
+function tile(label: string): HTMLElement {
+  const div = document.createElement('div');
+  div.textContent = label;
+  div.style.padding = '16px';
+  div.style.background = 'var(--bg-surface-2, #f4f4f5)';
+  div.style.borderRadius = '8px';
+  div.style.textAlign = 'center';
+  return div;
+}
+
+export const Grid2Cols: StoryObj = {
+  name: 'Grid / 2 columns',
+  render: () => host(grid({ cols: 2, children: ['A', 'B', 'C', 'D'].map(tile) })),
+};
+
+export const Grid3ColsLgGap: StoryObj = {
+  name: 'Grid / 3 columns, large gap',
+  render: () =>
+    host(grid({ cols: 3, gap: 'lg', children: ['1', '2', '3', '4', '5', '6'].map(tile) })),
+};
+
+export const FormGridBasic: StoryObj = {
+  name: 'Form grid / Basic',
+  render: () => {
+    function input(id: string, placeholder: string): HTMLInputElement {
+      const el = document.createElement('input');
+      el.id = id;
+      el.placeholder = placeholder;
+      el.style.padding = '8px 12px';
+      el.style.border = '1px solid var(--line, #e5e7eb)';
+      el.style.borderRadius = '6px';
+      el.style.font = 'inherit';
+      el.style.width = '100%';
+      return el;
+    }
+    return host(
+      formGrid({
+        entries: [
+          { label: 'Slug', field: input('slug', 'kebab-case') },
+          { label: 'Name', field: input('name', 'Tool name'), hint: 'Shown in the sidebar.' },
+          { label: 'Description', field: input('desc', 'One-liner') },
+        ],
+      }),
+    );
+  },
+};
+
+export const PushHeader: StoryObj = {
+  name: 'Push / Header pattern',
+  render: () => {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.gap = '8px';
+    row.style.padding = '12px';
+    row.style.background = 'var(--bg-surface, #fff)';
+    row.style.border = '1px solid var(--line, #e5e7eb)';
+    row.style.borderRadius = '8px';
+
+    const title = document.createElement('strong');
+    title.textContent = 'Tool title';
+    row.appendChild(title);
+
+    row.appendChild(push());
+
+    const a1 = document.createElement('button');
+    a1.textContent = 'Action A';
+    const a2 = document.createElement('button');
+    a2.textContent = 'Action B';
+    row.appendChild(a1);
+    row.appendChild(a2);
+
+    return host(row);
+  },
+};
+
+export const GrowSearchRow: StoryObj = {
+  name: 'Grow / Search input dominates the row',
+  render: () => {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.gap = '8px';
+    row.style.alignItems = 'center';
+
+    const search = document.createElement('input');
+    search.placeholder = 'Search tools…';
+    search.style.padding = '8px 12px';
+    search.style.border = '1px solid var(--line, #e5e7eb)';
+    search.style.borderRadius = '6px';
+    search.style.font = 'inherit';
+    search.style.width = '100%';
+
+    const filterBtn = document.createElement('button');
+    filterBtn.textContent = 'Filter';
+
+    row.appendChild(grow({ children: [search] }));
+    row.appendChild(filterBtn);
+
+    return host(row);
+  },
+};

--- a/src/stories/00-foundations/primitives.stories.ts
+++ b/src/stories/00-foundations/primitives.stories.ts
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import '../_styles/foundations.css';
+import { segment } from '../../ui/primitives/segment';
+import { status, type StatusTone } from '../../ui/primitives/status';
+import { stat, statGrid } from '../../ui/primitives/stat';
+
+interface SegmentArgs {
+  items: string[];
+  selected: number;
+  tone: 'primary' | 'secondary';
+}
+
+const meta: Meta<SegmentArgs> = {
+  title: 'Foundations / Primitives / Segment',
+  argTypes: {
+    items: { control: 'object' },
+    selected: { control: { type: 'number', min: 0, max: 5, step: 1 } },
+    tone: { control: 'inline-radio', options: ['primary', 'secondary'] },
+  },
+  args: {
+    items: ['Encode', 'Decode'],
+    selected: 0,
+    tone: 'primary',
+  },
+};
+
+export default meta;
+
+function host(child: HTMLElement): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'dt-foundation-host';
+  root.style.padding = '24px';
+  root.appendChild(child);
+  return root;
+}
+
+export const SegmentDefault: StoryObj<SegmentArgs> = {
+  name: 'Segment / Default',
+  render: (args) => host(segment({ items: args.items, selected: args.selected, tone: args.tone })),
+};
+
+export const SegmentSecondary: StoryObj<SegmentArgs> = {
+  name: 'Segment / Secondary',
+  render: (args) =>
+    host(segment({ items: args.items, selected: args.selected, tone: 'secondary' })),
+};
+
+export const SegmentManyOptions: StoryObj<SegmentArgs> = {
+  name: 'Segment / Many options',
+  render: () =>
+    host(
+      segment({
+        items: ['UTF-8', 'Latin-1', 'ASCII', 'Hex', 'Base64', 'Base64URL'],
+        selected: 0,
+        ariaLabel: 'Encoding',
+      }),
+    ),
+};
+
+const STATUS_TONES: readonly StatusTone[] = ['neutral', 'success', 'danger', 'warning', 'info'];
+
+export const StatusAllTones: StoryObj = {
+  name: 'Status / All tones',
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.display = 'flex';
+    wrap.style.gap = '12px';
+    wrap.style.flexWrap = 'wrap';
+    for (const tone of STATUS_TONES) {
+      wrap.appendChild(status({ label: tone, tone }));
+    }
+    return host(wrap);
+  },
+};
+
+export const StatSingle: StoryObj = {
+  name: 'Stat / Single',
+  render: () =>
+    host(stat({ label: 'Tools shipped', value: '42', delta: '+3 this week', deltaPositive: true })),
+};
+
+export const StatGrid: StoryObj = {
+  name: 'Stat / Grid',
+  render: () =>
+    host(
+      statGrid({
+        stats: [
+          { label: 'Tools shipped', value: '42', delta: '+3', deltaPositive: true },
+          { label: 'Bugs open', value: '7', delta: '-2', deltaPositive: false },
+          { label: 'Locales', value: '15' },
+          { label: 'Tests passing', value: '532' },
+        ],
+      }),
+    ),
+};

--- a/src/stories/_styles/foundations.css
+++ b/src/stories/_styles/foundations.css
@@ -1,0 +1,286 @@
+/*
+ * Storybook-only stylesheet for the SB-14 primitives, layout utils, and
+ * data displays. Imported by the foundation stories so they render with
+ * design tokens applied.
+ *
+ * Tokens here are intentionally local-scope (`:where(.dt-foundation-host)`)
+ * to avoid clobbering the live app's `src/style.css`. SB-16 (#54) will
+ * later promote these into the canonical `src/styles/system-tokens.css`
+ * and `src/styles/system-components.css`.
+ */
+
+:where(.dt-foundation-host) {
+  --dt-success: #22c55e;
+  --dt-success-fg: #052e16;
+  --dt-danger: #ef4444;
+  --dt-danger-fg: #450a0a;
+  --dt-warning: #f59e0b;
+  --dt-warning-fg: #451a03;
+  --dt-info: #3b82f6;
+  --dt-info-fg: #0c1e3d;
+  --dt-neutral: var(--bg-surface-2, #f4f4f5);
+  --dt-neutral-fg: var(--fg-default, #111);
+  --dt-shadow-2: 0 4px 12px rgb(0 0 0 / 0.08);
+  --dt-radius: 8px;
+  --dt-radius-sm: 6px;
+  --dt-radius-lg: 12px;
+  --dt-gap-sm: 8px;
+  --dt-gap-md: 16px;
+  --dt-gap-lg: 24px;
+}
+
+/* ---------- segment ---------- */
+.dt-segment {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: var(--dt-radius);
+  background: var(--bg-surface-2, #f4f4f5);
+}
+
+.dt-segment__item {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 6px 12px;
+  font: inherit;
+  color: var(--fg-muted, #555);
+  border-radius: calc(var(--dt-radius) - 2px);
+  cursor: pointer;
+}
+
+.dt-segment__item[data-state='active'] {
+  background: var(--bg-surface, #fff);
+  color: var(--fg-default, #111);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);
+}
+
+.dt-segment--secondary {
+  background: transparent;
+  border: 1px solid var(--line, #e5e7eb);
+}
+
+/* ---------- status ---------- */
+.dt-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--dt-neutral);
+  color: var(--dt-neutral-fg);
+}
+
+.dt-status[data-tone='success'] {
+  background: var(--dt-success);
+  color: var(--dt-success-fg);
+}
+.dt-status[data-tone='danger'] {
+  background: var(--dt-danger);
+  color: var(--dt-danger-fg);
+}
+.dt-status[data-tone='warning'] {
+  background: var(--dt-warning);
+  color: var(--dt-warning-fg);
+}
+.dt-status[data-tone='info'] {
+  background: var(--dt-info);
+  color: var(--dt-info-fg);
+}
+
+.dt-status__icon {
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+}
+
+/* ---------- stat ---------- */
+.dt-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: var(--dt-radius);
+  background: var(--bg-surface, #fff);
+  box-shadow: var(--dt-shadow-2);
+}
+
+.dt-stat__label {
+  font-size: 12px;
+  color: var(--fg-muted, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dt-stat__value {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--fg-default, #111);
+}
+
+.dt-stat__delta {
+  font-size: 12px;
+  color: var(--fg-muted, #555);
+}
+
+.dt-stat__delta[data-trend='up'] {
+  color: var(--dt-success);
+}
+.dt-stat__delta[data-trend='down'] {
+  color: var(--dt-danger);
+}
+
+.dt-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--dt-gap-md);
+}
+
+/* ---------- layout ---------- */
+.dt-grid {
+  display: grid;
+  gap: var(--dt-gap-md);
+}
+
+.dt-grid[data-gap='sm'] {
+  gap: var(--dt-gap-sm);
+}
+.dt-grid[data-gap='lg'] {
+  gap: var(--dt-gap-lg);
+}
+
+.dt-grid[data-cols='1'] {
+  grid-template-columns: 1fr;
+}
+.dt-grid[data-cols='2'] {
+  grid-template-columns: repeat(2, 1fr);
+}
+.dt-grid[data-cols='3'] {
+  grid-template-columns: repeat(3, 1fr);
+}
+.dt-grid[data-cols='4'] {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.dt-form-grid {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 3fr;
+  gap: var(--dt-gap-md);
+  align-items: start;
+}
+
+.dt-form-grid__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--fg-default, #111);
+  padding-top: 6px;
+}
+
+.dt-form-grid__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.dt-form-grid__hint {
+  font-size: 12px;
+  color: var(--fg-muted, #555);
+  margin: 0;
+}
+
+.dt-push {
+  margin-left: auto;
+}
+
+.dt-grow {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+/* ---------- data display ---------- */
+.dt-kv-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+}
+
+.dt-kv-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) 2fr auto;
+  gap: var(--dt-gap-md);
+  align-items: center;
+  padding: 8px 12px;
+  background: var(--bg-surface, #fff);
+  border: 1px solid var(--line, #e5e7eb);
+  border-radius: var(--dt-radius-sm);
+}
+
+.dt-kv-row__key {
+  font-size: 12px;
+  color: var(--fg-muted, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.dt-kv-row__value {
+  font-size: 14px;
+  color: var(--fg-default, #111);
+  margin: 0;
+}
+
+.dt-kv-row__value--mono {
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 13px;
+}
+
+.dt-kv-row__action {
+  display: inline-flex;
+}
+
+.dt-output {
+  margin: 0;
+  padding: 12px 16px;
+  background: var(--bg-surface-2, #f8f8f9);
+  border: 1px solid var(--line, #e5e7eb);
+  border-radius: var(--dt-radius);
+  overflow: auto;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg-default, #111);
+}
+
+.dt-output__code {
+  font: inherit;
+  color: inherit;
+  white-space: pre;
+}
+
+.dt-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  background: var(--bg-surface, #fff);
+  border: 1px dashed var(--line, #d4d4d8);
+  border-radius: var(--dt-radius);
+}
+
+.dt-preview__caption {
+  font-size: 12px;
+  color: var(--fg-muted, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dt-preview__body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+}

--- a/src/ui/_helpers/variants.test.ts
+++ b/src/ui/_helpers/variants.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { variants } from './variants';
+
+describe('variants', () => {
+  it('returns base alone when no variants selected and no defaults', () => {
+    const cls = variants({ base: 'dt-foo', variants: {} });
+    expect(cls()).toBe('dt-foo');
+  });
+
+  it('applies the default variant when none is selected', () => {
+    const cls = variants({
+      base: 'dt-foo',
+      variants: { tone: { primary: 'dt-foo--primary', secondary: 'dt-foo--secondary' } },
+      defaultVariants: { tone: 'primary' },
+    });
+    expect(cls()).toBe('dt-foo dt-foo--primary');
+  });
+
+  it('overrides the default variant when an option is provided', () => {
+    const cls = variants({
+      base: 'dt-foo',
+      variants: { tone: { primary: 'dt-foo--primary', secondary: 'dt-foo--secondary' } },
+      defaultVariants: { tone: 'primary' },
+    });
+    expect(cls({ tone: 'secondary' })).toBe('dt-foo dt-foo--secondary');
+  });
+
+  it('skips empty class strings cleanly', () => {
+    const cls = variants({
+      base: 'dt-foo',
+      variants: { size: { sm: 'dt-foo--sm', md: '' } },
+      defaultVariants: { size: 'md' },
+    });
+    expect(cls()).toBe('dt-foo');
+  });
+
+  it('combines multiple variant groups', () => {
+    const cls = variants({
+      base: 'dt-btn',
+      variants: {
+        tone: { primary: 'dt-btn--primary', danger: 'dt-btn--danger' },
+        size: { sm: 'dt-btn--sm', md: 'dt-btn--md' },
+      },
+      defaultVariants: { tone: 'primary', size: 'md' },
+    });
+    expect(cls({ tone: 'danger' })).toBe('dt-btn dt-btn--danger dt-btn--md');
+    expect(cls({ size: 'sm' })).toBe('dt-btn dt-btn--primary dt-btn--sm');
+    expect(cls({})).toBe('dt-btn dt-btn--primary dt-btn--md');
+  });
+
+  it('omits a group entirely when neither selected nor default is provided', () => {
+    const cls = variants({
+      base: 'dt-btn',
+      variants: { tone: { primary: 'dt-btn--primary' } },
+    });
+    expect(cls()).toBe('dt-btn');
+  });
+
+  it('omits the base when not provided', () => {
+    const cls = variants({
+      variants: { tone: { primary: 'dt-btn--primary' } },
+      defaultVariants: { tone: 'primary' },
+    });
+    expect(cls()).toBe('dt-btn--primary');
+  });
+});

--- a/src/ui/_helpers/variants.ts
+++ b/src/ui/_helpers/variants.ts
@@ -1,0 +1,56 @@
+/**
+ * Tiny CVA-style variant helper. Given a base class plus a map of
+ * variant groups (e.g. `tone`, `size`) where each group maps option
+ * names to class strings, returns a builder that takes an options
+ * object and produces the final class list.
+ *
+ * Example:
+ *   const segment = variants({
+ *     base: 'dt-segment',
+ *     variants: {
+ *       tone: { primary: 'dt-segment--primary', secondary: '' },
+ *     },
+ *     defaultVariants: { tone: 'primary' },
+ *   });
+ *   segment({ tone: 'secondary' }); // 'dt-segment'
+ *   segment();                       // 'dt-segment dt-segment--primary'
+ *
+ * Type-safe: the returned builder only accepts variant keys/values
+ * declared in the config, and reports unknown values as compile errors.
+ */
+
+type VariantMap = Record<string, Record<string, string>>;
+
+type SelectedVariants<V extends VariantMap> = {
+  readonly [K in keyof V]?: keyof V[K];
+};
+
+interface VariantsConfig<V extends VariantMap> {
+  readonly base?: string;
+  readonly variants: V;
+  readonly defaultVariants?: SelectedVariants<V>;
+}
+
+export function variants<V extends VariantMap>(
+  config: VariantsConfig<V>,
+): (selected?: SelectedVariants<V>) => string {
+  const base = config.base ?? '';
+  const groups = config.variants;
+  const defaults: SelectedVariants<V> = config.defaultVariants ?? {};
+
+  return (selected: SelectedVariants<V> = {}): string => {
+    const parts: string[] = [];
+    if (base.length > 0) parts.push(base);
+    for (const groupName of Object.keys(groups) as (keyof V & string)[]) {
+      const picked = selected[groupName] ?? defaults[groupName];
+      if (picked === undefined) continue;
+      const group = groups[groupName];
+      if (group === undefined) continue;
+      const className = group[picked as string];
+      if (typeof className === 'string' && className.length > 0) {
+        parts.push(className);
+      }
+    }
+    return parts.join(' ');
+  };
+}

--- a/src/ui/data-display/data-display.test.ts
+++ b/src/ui/data-display/data-display.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { kvRow } from './kv-row';
+import { kvList } from './kv-list';
+import { output } from './output';
+import { preview } from './preview';
+
+describe('kvRow', () => {
+  it('renders dt + dd with the provided key + value', () => {
+    const handle = kvRow({ key: 'Name', value: 'Pratiyush' });
+    const dt = handle.el.querySelector('dt.dt-kv-row__key');
+    const dd = handle.el.querySelector('dd.dt-kv-row__value');
+    expect(dt?.textContent).toBe('Name');
+    expect(dd?.textContent).toBe('Pratiyush');
+  });
+
+  it('skips the copy button by default', () => {
+    const handle = kvRow({ key: 'k', value: 'v' });
+    expect(handle.el.querySelector('.dt-kv-row__action')).toBeNull();
+  });
+
+  it('renders a copy button when copyable is true', () => {
+    const handle = kvRow({ key: 'k', value: 'v', copyable: true });
+    expect(handle.el.querySelector('.dt-kv-row__action')).not.toBeNull();
+    expect(handle.el.querySelector('button.dt-copy')).not.toBeNull();
+  });
+
+  it('applies mono modifier on the value when mono is true', () => {
+    const handle = kvRow({ key: 'k', value: 'v', mono: true });
+    expect(handle.el.querySelector('.dt-kv-row__value--mono')).not.toBeNull();
+  });
+
+  it('dispose is a no-op when no copy button was created', () => {
+    const handle = kvRow({ key: 'k', value: 'v' });
+    expect(() => handle.dispose()).not.toThrow();
+  });
+
+  it('dispose removes the copy button listeners (smoke)', () => {
+    const handle = kvRow({ key: 'k', value: 'v', copyable: true });
+    handle.dispose();
+    // Re-disposing should not throw.
+    expect(() => handle.dispose()).not.toThrow();
+  });
+});
+
+describe('kvList', () => {
+  it('wraps multiple rows inside a <dl class="dt-kv-list">', () => {
+    const handle = kvList({
+      entries: [
+        { key: 'A', value: '1' },
+        { key: 'B', value: '2' },
+      ],
+    });
+    expect(handle.el.tagName).toBe('DL');
+    expect(handle.el.classList.contains('dt-kv-list')).toBe(true);
+    expect(handle.el.querySelectorAll('.dt-kv-row')).toHaveLength(2);
+  });
+
+  it('disposes every row', () => {
+    const handle = kvList({ entries: [{ key: 'A', value: '1', copyable: true }] });
+    expect(() => handle.dispose()).not.toThrow();
+  });
+});
+
+describe('output', () => {
+  it('renders <pre><code> with the content', () => {
+    const el = output({ content: 'hello\nworld' });
+    expect(el.tagName).toBe('PRE');
+    expect(el.classList.contains('dt-output')).toBe(true);
+    expect(el.querySelector('code.dt-output__code')?.textContent).toBe('hello\nworld');
+  });
+
+  it('writes data-language when provided', () => {
+    const el = output({ content: '{}', language: 'json' });
+    expect(el.dataset.language).toBe('json');
+  });
+
+  it('preserves textual content without HTML interpretation', () => {
+    const el = output({ content: '<script>alert(1)</script>' });
+    expect(el.querySelector('.dt-output__code')?.innerHTML).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+  });
+});
+
+describe('preview', () => {
+  it('mounts the provided content into the body', () => {
+    const child = document.createElement('button');
+    child.textContent = 'Click me';
+    const el = preview({ content: child });
+    expect(el.classList.contains('dt-preview')).toBe(true);
+    expect(el.querySelector('.dt-preview__body')?.firstChild).toBe(child);
+  });
+
+  it('renders caption when provided', () => {
+    const el = preview({ caption: 'Live preview', content: document.createElement('span') });
+    expect(el.querySelector('.dt-preview__caption')?.textContent).toBe('Live preview');
+  });
+
+  it('omits caption when not provided', () => {
+    const el = preview({ content: document.createElement('span') });
+    expect(el.querySelector('.dt-preview__caption')).toBeNull();
+  });
+});

--- a/src/ui/data-display/kv-list.ts
+++ b/src/ui/data-display/kv-list.ts
@@ -1,0 +1,34 @@
+/**
+ * `.dt-kv-list` — a `<dl>` container holding multiple `kvRow`s.
+ * Returns a handle that disposes every nested copy-button.
+ */
+
+import { kvRow, type KvRowHandle, type KvRowOptions } from './kv-row';
+
+export interface KvListOptions {
+  readonly entries: readonly KvRowOptions[];
+}
+
+export interface KvListHandle {
+  readonly el: HTMLDListElement;
+  dispose(): void;
+}
+
+export function kvList(options: KvListOptions): KvListHandle {
+  const root = document.createElement('dl');
+  root.className = 'dt-kv-list';
+
+  const handles: KvRowHandle[] = [];
+  for (const entry of options.entries) {
+    const handle = kvRow(entry);
+    handles.push(handle);
+    root.appendChild(handle.el);
+  }
+
+  return {
+    el: root,
+    dispose: () => {
+      for (const handle of handles) handle.dispose();
+    },
+  };
+}

--- a/src/ui/data-display/kv-row.ts
+++ b/src/ui/data-display/kv-row.ts
@@ -1,0 +1,58 @@
+/**
+ * `.dt-kv-row` — a single key/value row with optional copy button.
+ * Used as the building block for `kvList`.
+ *
+ * The copy-button primitive returns a handle with a `dispose()` method;
+ * we expose a `KvRowHandle` that bundles the row element with that
+ * disposer (a no-op when the row has no copy button).
+ */
+
+import { copyButton } from '../primitives/copy-button';
+
+export interface KvRowOptions {
+  readonly key: string;
+  readonly value: string;
+  readonly copyable?: boolean;
+  readonly mono?: boolean;
+}
+
+export interface KvRowHandle {
+  readonly el: HTMLDivElement;
+  dispose(): void;
+}
+
+export function kvRow(options: KvRowOptions): KvRowHandle {
+  const root = document.createElement('div');
+  root.className = 'dt-kv-row';
+
+  const keyEl = document.createElement('dt');
+  keyEl.className = 'dt-kv-row__key';
+  keyEl.textContent = options.key;
+  root.appendChild(keyEl);
+
+  const valueEl = document.createElement('dd');
+  valueEl.className = 'dt-kv-row__value';
+  if (options.mono === true) valueEl.classList.add('dt-kv-row__value--mono');
+  valueEl.textContent = options.value;
+  root.appendChild(valueEl);
+
+  let dispose: () => void = noop;
+
+  if (options.copyable === true) {
+    const action = document.createElement('div');
+    action.className = 'dt-kv-row__action';
+    const handle = copyButton({ text: () => options.value });
+    action.appendChild(handle.el);
+    root.appendChild(action);
+    dispose = () => handle.dispose();
+  }
+
+  return {
+    el: root,
+    dispose: () => dispose(),
+  };
+}
+
+function noop(): void {
+  // intentionally empty — used when there is nothing to dispose.
+}

--- a/src/ui/data-display/output.ts
+++ b/src/ui/data-display/output.ts
@@ -1,0 +1,25 @@
+/**
+ * `.dt-output` — pre-formatted output block. Uses `<pre><code>` so monospace
+ * + whitespace preservation are inherited. `language` is written to
+ * `data-language` for future syntax-highlight integration.
+ */
+
+export interface OutputOptions {
+  readonly content: string;
+  readonly language?: string;
+  readonly ariaLabel?: string;
+}
+
+export function output(options: OutputOptions): HTMLPreElement {
+  const root = document.createElement('pre');
+  root.className = 'dt-output';
+  if (options.language !== undefined) root.dataset.language = options.language;
+  if (options.ariaLabel !== undefined) root.setAttribute('aria-label', options.ariaLabel);
+
+  const code = document.createElement('code');
+  code.className = 'dt-output__code';
+  code.textContent = options.content;
+  root.appendChild(code);
+
+  return root;
+}

--- a/src/ui/data-display/preview.ts
+++ b/src/ui/data-display/preview.ts
@@ -1,0 +1,29 @@
+/**
+ * `.dt-preview` — rendered preview pane. The contents are appended as DOM
+ * (no innerHTML), so callers control sanitization. Optional caption
+ * is rendered above the content as a subtle label.
+ */
+
+export interface PreviewOptions {
+  readonly caption?: string;
+  readonly content: HTMLElement;
+}
+
+export function preview(options: PreviewOptions): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-preview';
+
+  if (options.caption !== undefined) {
+    const captionEl = document.createElement('span');
+    captionEl.className = 'dt-preview__caption';
+    captionEl.textContent = options.caption;
+    root.appendChild(captionEl);
+  }
+
+  const body = document.createElement('div');
+  body.className = 'dt-preview__body';
+  body.appendChild(options.content);
+  root.appendChild(body);
+
+  return root;
+}

--- a/src/ui/layout/form-grid.ts
+++ b/src/ui/layout/form-grid.ts
@@ -1,0 +1,42 @@
+/**
+ * `.dt-form-grid` — two-column label/field grid. Each entry is a `{ label,
+ * field }` pair; a `<label>` tag is generated and tied to the field via
+ * `htmlFor` when the field has an `id`.
+ */
+
+export interface FormGridEntry {
+  readonly label: string;
+  readonly field: HTMLElement;
+  readonly hint?: string;
+}
+
+export interface FormGridOptions {
+  readonly entries: readonly FormGridEntry[];
+}
+
+export function formGrid(options: FormGridOptions): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-form-grid';
+
+  for (const entry of options.entries) {
+    const labelEl = document.createElement('label');
+    labelEl.className = 'dt-form-grid__label';
+    labelEl.textContent = entry.label;
+    if (entry.field.id !== '') labelEl.htmlFor = entry.field.id;
+
+    const fieldWrap = document.createElement('div');
+    fieldWrap.className = 'dt-form-grid__field';
+    fieldWrap.appendChild(entry.field);
+    if (entry.hint !== undefined) {
+      const hintEl = document.createElement('p');
+      hintEl.className = 'dt-form-grid__hint';
+      hintEl.textContent = entry.hint;
+      fieldWrap.appendChild(hintEl);
+    }
+
+    root.appendChild(labelEl);
+    root.appendChild(fieldWrap);
+  }
+
+  return root;
+}

--- a/src/ui/layout/grid.ts
+++ b/src/ui/layout/grid.ts
@@ -1,0 +1,28 @@
+/**
+ * `.dt-grid` — a CSS grid wrapper. `cols` controls column count;
+ * `gap` selects a token-driven gap size (`sm` / `md` / `lg`).
+ */
+
+export type GridGap = 'sm' | 'md' | 'lg';
+
+export interface GridOptions {
+  readonly cols?: number;
+  readonly gap?: GridGap;
+  readonly children?: readonly HTMLElement[];
+}
+
+export function grid(options: GridOptions = {}): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-grid';
+  const cols = options.cols ?? 1;
+  if (cols < 1) {
+    root.dataset.cols = '1';
+  } else {
+    root.dataset.cols = String(cols);
+  }
+  root.dataset.gap = options.gap ?? 'md';
+  if (options.children !== undefined) {
+    for (const child of options.children) root.appendChild(child);
+  }
+  return root;
+}

--- a/src/ui/layout/grow.ts
+++ b/src/ui/layout/grow.ts
@@ -1,0 +1,18 @@
+/**
+ * `.dt-grow` — wrapper that flex-grows to fill remaining space. Pair with
+ * `dt-push` for asymmetric layouts, or use alone when one child needs
+ * to dominate the row.
+ */
+
+export interface GrowOptions {
+  readonly children?: readonly HTMLElement[];
+}
+
+export function grow(options: GrowOptions = {}): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-grow';
+  if (options.children !== undefined) {
+    for (const child of options.children) root.appendChild(child);
+  }
+  return root;
+}

--- a/src/ui/layout/layout.test.ts
+++ b/src/ui/layout/layout.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { grid } from './grid';
+import { formGrid } from './form-grid';
+import { push } from './push';
+import { grow } from './grow';
+
+describe('grid', () => {
+  it('defaults cols to 1 and gap to md', () => {
+    const el = grid();
+    expect(el.classList.contains('dt-grid')).toBe(true);
+    expect(el.dataset.cols).toBe('1');
+    expect(el.dataset.gap).toBe('md');
+  });
+
+  it('clamps invalid cols to 1', () => {
+    const el = grid({ cols: 0 });
+    expect(el.dataset.cols).toBe('1');
+  });
+
+  it('writes provided cols and gap', () => {
+    const el = grid({ cols: 4, gap: 'lg' });
+    expect(el.dataset.cols).toBe('4');
+    expect(el.dataset.gap).toBe('lg');
+  });
+
+  it('appends children in order', () => {
+    const a = document.createElement('span');
+    const b = document.createElement('span');
+    const el = grid({ children: [a, b] });
+    expect(el.children).toHaveLength(2);
+    expect(el.children[0]).toBe(a);
+    expect(el.children[1]).toBe(b);
+  });
+});
+
+describe('formGrid', () => {
+  it('renders one label/field pair per entry', () => {
+    const f1 = document.createElement('input');
+    f1.id = 'in1';
+    const f2 = document.createElement('input');
+    f2.id = 'in2';
+    const el = formGrid({
+      entries: [
+        { label: 'Name', field: f1 },
+        { label: 'Email', field: f2 },
+      ],
+    });
+    const labels = el.querySelectorAll<HTMLLabelElement>('.dt-form-grid__label');
+    const fields = el.querySelectorAll('.dt-form-grid__field');
+    expect(labels).toHaveLength(2);
+    expect(fields).toHaveLength(2);
+    expect(labels[0]?.htmlFor).toBe('in1');
+    expect(labels[1]?.htmlFor).toBe('in2');
+  });
+
+  it('skips htmlFor when the field has no id', () => {
+    const f = document.createElement('input');
+    const el = formGrid({ entries: [{ label: 'X', field: f }] });
+    const label = el.querySelector<HTMLLabelElement>('.dt-form-grid__label');
+    expect(label?.htmlFor).toBe('');
+  });
+
+  it('renders hint when provided', () => {
+    const f = document.createElement('input');
+    f.id = 'h';
+    const el = formGrid({ entries: [{ label: 'X', field: f, hint: 'Optional' }] });
+    expect(el.querySelector('.dt-form-grid__hint')?.textContent).toBe('Optional');
+  });
+});
+
+describe('push', () => {
+  it('renders a hidden spacer', () => {
+    const el = push();
+    expect(el.classList.contains('dt-push')).toBe(true);
+    expect(el.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+describe('grow', () => {
+  it('renders an empty .dt-grow when no children', () => {
+    const el = grow();
+    expect(el.classList.contains('dt-grow')).toBe(true);
+    expect(el.children).toHaveLength(0);
+  });
+
+  it('appends children in order', () => {
+    const a = document.createElement('span');
+    const b = document.createElement('span');
+    const el = grow({ children: [a, b] });
+    expect(el.children).toHaveLength(2);
+  });
+});

--- a/src/ui/layout/push.ts
+++ b/src/ui/layout/push.ts
@@ -1,0 +1,12 @@
+/**
+ * `.dt-push` — invisible flex spacer that pushes everything after it to
+ * the end of the line via `margin-left: auto`. Common pattern: header
+ * with title + push + actions.
+ */
+
+export function push(): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-push';
+  root.setAttribute('aria-hidden', 'true');
+  return root;
+}

--- a/src/ui/primitives/segment.test.ts
+++ b/src/ui/primitives/segment.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { segment, type SegmentChangeDetail } from './segment';
+
+function selected(root: HTMLElement): number {
+  const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('.dt-segment__item'));
+  return buttons.findIndex((b) => b.dataset.state === 'active');
+}
+
+describe('segment', () => {
+  it('renders one button per item with the first selected by default', () => {
+    const el = segment({ items: ['One', 'Two', 'Three'] });
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.dt-segment__item');
+    expect(buttons).toHaveLength(3);
+    expect(selected(el)).toBe(0);
+    expect(buttons[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(buttons[1]?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('honors initial selected index', () => {
+    const el = segment({ items: ['A', 'B', 'C'], selected: 2 });
+    expect(selected(el)).toBe(2);
+  });
+
+  it('clamps out-of-range initial index', () => {
+    const el = segment({ items: ['A', 'B'], selected: 99 });
+    expect(selected(el)).toBe(1);
+  });
+
+  it('writes data-tone attribute', () => {
+    const el = segment({ items: ['A'], tone: 'secondary' });
+    expect(el.dataset.tone).toBe('secondary');
+    expect(el.classList.contains('dt-segment--secondary')).toBe(true);
+  });
+
+  it('cycles selection on click and fires dt-segment-change', () => {
+    const el = segment({ items: ['A', 'B', 'C'] });
+    const seen: SegmentChangeDetail[] = [];
+    el.addEventListener('dt-segment-change', (e) =>
+      seen.push((e as CustomEvent<SegmentChangeDetail>).detail),
+    );
+    const buttons = el.querySelectorAll<HTMLButtonElement>('.dt-segment__item');
+    buttons[1]?.click();
+    expect(selected(el)).toBe(1);
+    expect(seen).toEqual([{ index: 1, value: 'B' }]);
+  });
+
+  it('ArrowRight wraps from last to first', () => {
+    const el = segment({ items: ['A', 'B', 'C'], selected: 2 });
+    const last = el.querySelectorAll<HTMLButtonElement>('.dt-segment__item')[2];
+    last?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    expect(selected(el)).toBe(0);
+  });
+
+  it('ArrowLeft wraps from first to last', () => {
+    const el = segment({ items: ['A', 'B', 'C'] });
+    const first = el.querySelectorAll<HTMLButtonElement>('.dt-segment__item')[0];
+    first?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    expect(selected(el)).toBe(2);
+  });
+
+  it('Home / End jump to first / last', () => {
+    const el = segment({ items: ['A', 'B', 'C'] });
+    const second = el.querySelectorAll<HTMLButtonElement>('.dt-segment__item')[1];
+    second?.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+    expect(selected(el)).toBe(2);
+    const last = el.querySelectorAll<HTMLButtonElement>('.dt-segment__item')[2];
+    last?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+    expect(selected(el)).toBe(0);
+  });
+
+  it('invokes onChange callback', () => {
+    const calls: number[] = [];
+    const el = segment({ items: ['A', 'B'], onChange: (i) => calls.push(i) });
+    el.querySelectorAll<HTMLButtonElement>('.dt-segment__item')[1]?.click();
+    expect(calls).toEqual([1]);
+  });
+
+  it('uses ariaLabel when provided', () => {
+    const el = segment({ items: ['A'], ariaLabel: 'Encoding' });
+    expect(el.getAttribute('aria-label')).toBe('Encoding');
+  });
+});

--- a/src/ui/primitives/segment.ts
+++ b/src/ui/primitives/segment.ts
@@ -1,0 +1,114 @@
+/**
+ * `.dt-segment` — segmented control. Keyboard nav: ArrowLeft / ArrowRight
+ * cycles selection. Fires `dt-segment-change` CustomEvent on change.
+ *
+ * Markup:
+ *   <div class="dt-segment" role="tablist" data-tone="primary">
+ *     <button class="dt-segment__item" role="tab" data-state="active|inactive">…</button>
+ *     …
+ *   </div>
+ */
+
+import { variants } from '../_helpers/variants';
+
+export type SegmentTone = 'primary' | 'secondary';
+
+export interface SegmentOptions {
+  readonly items: readonly string[];
+  readonly selected?: number;
+  readonly tone?: SegmentTone;
+  readonly ariaLabel?: string;
+  readonly onChange?: (index: number) => void;
+}
+
+export interface SegmentChangeDetail {
+  readonly index: number;
+  readonly value: string;
+}
+
+const segmentClass = variants({
+  base: 'dt-segment',
+  variants: {
+    tone: {
+      primary: '',
+      secondary: 'dt-segment--secondary',
+    },
+  },
+  defaultVariants: { tone: 'primary' },
+});
+
+export function segment(options: SegmentOptions): HTMLDivElement {
+  const tone: SegmentTone = options.tone ?? 'primary';
+  const root = document.createElement('div');
+  root.className = segmentClass({ tone });
+  root.setAttribute('role', 'tablist');
+  root.dataset.tone = tone;
+  if (options.ariaLabel !== undefined) root.setAttribute('aria-label', options.ariaLabel);
+
+  let selectedIndex = clampIndex(options.selected ?? 0, options.items.length);
+
+  const buttons: HTMLButtonElement[] = options.items.map((label, index) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'dt-segment__item';
+    button.textContent = label;
+    button.setAttribute('role', 'tab');
+    button.dataset.value = label;
+    applyState(button, index === selectedIndex);
+    button.addEventListener('click', () => activate(index));
+    button.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        activate((selectedIndex - 1 + options.items.length) % options.items.length);
+        buttons[selectedIndex]?.focus();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        activate((selectedIndex + 1) % options.items.length);
+        buttons[selectedIndex]?.focus();
+      } else if (event.key === 'Home') {
+        event.preventDefault();
+        activate(0);
+        buttons[selectedIndex]?.focus();
+      } else if (event.key === 'End') {
+        event.preventDefault();
+        activate(options.items.length - 1);
+        buttons[selectedIndex]?.focus();
+      }
+    });
+    return button;
+  });
+
+  for (const button of buttons) root.appendChild(button);
+
+  function activate(nextIndex: number): void {
+    if (nextIndex === selectedIndex) return;
+    selectedIndex = nextIndex;
+    for (let i = 0; i < buttons.length; i++) {
+      const button = buttons[i];
+      if (button !== undefined) applyState(button, i === selectedIndex);
+    }
+    const value = options.items[selectedIndex] ?? '';
+    options.onChange?.(selectedIndex);
+    root.dispatchEvent(
+      new CustomEvent<SegmentChangeDetail>('dt-segment-change', {
+        bubbles: true,
+        detail: { index: selectedIndex, value },
+      }),
+    );
+  }
+
+  return root;
+}
+
+function clampIndex(index: number, length: number): number {
+  if (length === 0) return 0;
+  if (index < 0) return 0;
+  if (index >= length) return length - 1;
+  return index;
+}
+
+function applyState(button: HTMLButtonElement, active: boolean): void {
+  button.dataset.state = active ? 'active' : 'inactive';
+  button.setAttribute('aria-selected', active ? 'true' : 'false');
+  button.tabIndex = active ? 0 : -1;
+}

--- a/src/ui/primitives/stat.test.ts
+++ b/src/ui/primitives/stat.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { stat, statGrid } from './stat';
+
+describe('stat', () => {
+  it('renders label and value', () => {
+    const el = stat({ label: 'Shipped', value: '42' });
+    expect(el.classList.contains('dt-stat')).toBe(true);
+    expect(el.querySelector('.dt-stat__label')?.textContent).toBe('Shipped');
+    expect(el.querySelector('.dt-stat__value')?.textContent).toBe('42');
+    expect(el.querySelector('.dt-stat__delta')).toBeNull();
+  });
+
+  it('renders delta with up trend when deltaPositive is true', () => {
+    const el = stat({ label: 'Up', value: '10', delta: '+1', deltaPositive: true });
+    const delta = el.querySelector<HTMLElement>('.dt-stat__delta');
+    expect(delta?.textContent).toBe('+1');
+    expect(delta?.dataset.trend).toBe('up');
+  });
+
+  it('renders delta with down trend when deltaPositive is false', () => {
+    const el = stat({ label: 'Down', value: '5', delta: '-2', deltaPositive: false });
+    const delta = el.querySelector<HTMLElement>('.dt-stat__delta');
+    expect(delta?.dataset.trend).toBe('down');
+  });
+
+  it('renders delta without trend attr when deltaPositive omitted', () => {
+    const el = stat({ label: 'Steady', value: '7', delta: 'no change' });
+    const delta = el.querySelector<HTMLElement>('.dt-stat__delta');
+    expect(delta?.textContent).toBe('no change');
+    expect(delta?.dataset.trend).toBeUndefined();
+  });
+});
+
+describe('statGrid', () => {
+  it('wraps multiple stats inside .dt-stat-grid', () => {
+    const el = statGrid({
+      stats: [
+        { label: 'A', value: '1' },
+        { label: 'B', value: '2' },
+        { label: 'C', value: '3' },
+      ],
+    });
+    expect(el.classList.contains('dt-stat-grid')).toBe(true);
+    expect(el.querySelectorAll('.dt-stat')).toHaveLength(3);
+  });
+
+  it('renders an empty grid for zero stats', () => {
+    const el = statGrid({ stats: [] });
+    expect(el.querySelectorAll('.dt-stat')).toHaveLength(0);
+  });
+});

--- a/src/ui/primitives/stat.ts
+++ b/src/ui/primitives/stat.ts
@@ -1,0 +1,61 @@
+/**
+ * `.dt-stat` — single stat card. Optional delta indicator with positive
+ * (`data-trend="up"`) or negative (`data-trend="down"`) styling.
+ *
+ * `.dt-stat-grid` — wrapper for laying out multiple stat cards.
+ *
+ * Markup:
+ *   <div class="dt-stat-grid">
+ *     <div class="dt-stat">
+ *       <span class="dt-stat__label">Tools shipped</span>
+ *       <span class="dt-stat__value">42</span>
+ *       <span class="dt-stat__delta" data-trend="up">+3 this week</span>
+ *     </div>
+ *     …
+ *   </div>
+ */
+
+export interface StatOptions {
+  readonly label: string;
+  readonly value: string;
+  readonly delta?: string;
+  readonly deltaPositive?: boolean;
+}
+
+export interface StatGridOptions {
+  readonly stats: readonly StatOptions[];
+}
+
+export function stat(options: StatOptions): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-stat';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'dt-stat__label';
+  labelEl.textContent = options.label;
+  root.appendChild(labelEl);
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'dt-stat__value';
+  valueEl.textContent = options.value;
+  root.appendChild(valueEl);
+
+  if (options.delta !== undefined) {
+    const deltaEl = document.createElement('span');
+    deltaEl.className = 'dt-stat__delta';
+    deltaEl.textContent = options.delta;
+    if (options.deltaPositive !== undefined) {
+      deltaEl.dataset.trend = options.deltaPositive ? 'up' : 'down';
+    }
+    root.appendChild(deltaEl);
+  }
+
+  return root;
+}
+
+export function statGrid(options: StatGridOptions): HTMLDivElement {
+  const root = document.createElement('div');
+  root.className = 'dt-stat-grid';
+  for (const opts of options.stats) root.appendChild(stat(opts));
+  return root;
+}

--- a/src/ui/primitives/status.test.ts
+++ b/src/ui/primitives/status.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { status } from './status';
+
+describe('status', () => {
+  it('renders label inside a .dt-status span with data-tone', () => {
+    const el = status({ label: 'Active', tone: 'success' });
+    expect(el.tagName).toBe('SPAN');
+    expect(el.classList.contains('dt-status')).toBe(true);
+    expect(el.dataset.tone).toBe('success');
+    expect(el.querySelector('.dt-status__label')?.textContent).toBe('Active');
+  });
+
+  it('defaults tone to neutral when omitted', () => {
+    const el = status({ label: 'Idle' });
+    expect(el.dataset.tone).toBe('neutral');
+  });
+
+  it('inserts an icon element when provided and tags it', () => {
+    const icon = document.createElement('svg');
+    const el = status({ label: 'Warn', tone: 'warning', icon });
+    const inserted = el.querySelector('.dt-status__icon');
+    expect(inserted).toBe(icon);
+  });
+
+  it('renders without an icon when none is given', () => {
+    const el = status({ label: 'Plain' });
+    expect(el.querySelector('.dt-status__icon')).toBeNull();
+  });
+});

--- a/src/ui/primitives/status.ts
+++ b/src/ui/primitives/status.ts
@@ -1,0 +1,30 @@
+/**
+ * `.dt-status` — status badge. Tone drives color via `data-tone`; CSS picks
+ * up the design token (e.g. `var(--dt-success)`).
+ *
+ * Markup:
+ *   <span class="dt-status" data-tone="success">Active</span>
+ */
+
+export type StatusTone = 'success' | 'danger' | 'warning' | 'info' | 'neutral';
+
+export interface StatusOptions {
+  readonly label: string;
+  readonly tone?: StatusTone;
+  readonly icon?: HTMLElement;
+}
+
+export function status(options: StatusOptions): HTMLSpanElement {
+  const root = document.createElement('span');
+  root.className = 'dt-status';
+  root.dataset.tone = options.tone ?? 'neutral';
+  if (options.icon !== undefined) {
+    options.icon.classList.add('dt-status__icon');
+    root.appendChild(options.icon);
+  }
+  const label = document.createElement('span');
+  label.className = 'dt-status__label';
+  label.textContent = options.label;
+  root.appendChild(label);
+  return root;
+}


### PR DESCRIPTION
## Summary

Adds the design-system primitives the audit flagged as missing — but **only as new code**. Existing primitives are untouched per the Storybook-first / live-app-after policy (#70). A follow-up SB-14b will refactor existing primitives onto the variants helper later.

**Stacked on:** #73 (Day-E rest). Bottom-up: master ← #71 ← #72 ← #73 ← this PR.

Closes #52. Refs #70 (Storybook-first), #54 (SB-16 will consolidate \`foundations.css\` into \`src/styles/system-tokens.css\` later).

## What's new

### Variants helper
- \`src/ui/_helpers/variants.ts\` — type-safe CVA-style builder (~50 LoC, no external dep). \`variants({ base, variants, defaultVariants })\` returns \`(opts) => string\`.

### Primitives
- \`segment.ts\` — segmented control. WAI-ARIA tablist; ArrowLeft/Right/Home/End cycle; fires \`dt-segment-change\` CustomEvent.
- \`status.ts\` — pill badge with \`data-tone\` (success / danger / warning / info / neutral).
- \`stat.ts\` — single \`stat({ label, value, delta?, deltaPositive? })\` + \`statGrid({ stats })\`.

### Layout utilities
- \`grid.ts\` — CSS-grid wrapper with \`data-cols\` (1–4) + \`data-gap\` (sm/md/lg).
- \`form-grid.ts\` — label/field pairs; auto-ties \`htmlFor\` when the field has an \`id\`.
- \`push.ts\` — aria-hidden flex spacer (\`margin-left: auto\`).
- \`grow.ts\` — flex-grow:1 wrapper.

### Data displays
- \`kv-row.ts\` — \`<dt>/<dd>\` row with optional copy button. Returns a \`KvRowHandle\` with \`dispose()\` to clean up the wrapped \`copyButton\` listeners.
- \`kv-list.ts\` — \`<dl>\` container; aggregates dispose across rows.
- \`output.ts\` — \`<pre><code>\` block with optional \`data-language\`. Preserves whitespace + escapes HTML.
- \`preview.ts\` — content wrapper with optional caption.

### Storybook
- \`src/stories/_styles/foundations.css\` — locally scoped tokens + component CSS for the new primitives. Scoped under \`:where(.dt-foundation-host)\` so it never clobbers \`src/style.css\`. SB-16 (#54) will later promote these to canonical paths.
- \`src/stories/00-foundations/{primitives,layout,data-display}.stories.ts\` — every variant covered. 13 named exports.

## Tests

51 new vitest cases — total now **588** (was 537):

- \`variants.test.ts\` (7)
- \`segment.test.ts\` (10)
- \`status.test.ts\` (4)
- \`stat.test.ts\` (6)
- \`layout.test.ts\` — grid + form-grid + push + grow (10)
- \`data-display.test.ts\` — kv-row + kv-list + output + preview (14)

## Acceptance criteria (EARS)

- [x] **R4.1** — segment / status / stat each export an \`Options\` type and a factory returning \`HTMLElement\`.
- [x] **R4.4** — layout + data-display factories each export typed \`Options\`.
- [x] **R4.5** — every new foundation story should pass addon-a11y (verify in test plan below).
- [ ] R4.2 / R4.3 / R4.6 — deferred to **SB-14b** (refactor existing primitives onto \`variants()\`, add panel-shadow, add aria-invalid).

## Verification

- \`pnpm typecheck\` — clean.
- \`pnpm test\` — 588 tests pass.
- \`pnpm lint\` — 0 errors.
- \`pnpm format:check\` — clean.
- \`pnpm build-storybook\` — clean build.
- \`pnpm build\` — live app builds.

## Test plan

- [ ] Open Storybook → \`Foundations / Primitives / Segment / Default\` — switch tone via toolbar; confirm hover / active state / keyboard nav work.
- [ ] Open \`Foundations / Primitives / Status / All tones\` — verify color tokens differ per tone.
- [ ] Open \`Foundations / Primitives / Stat / Grid\` — confirm trend arrows colored per \`data-trend\`.
- [ ] Open \`Foundations / Layout\` — verify grid columns + push + grow patterns.
- [ ] Open \`Foundations / Data display / KV list / JWT decoded\` — click copy button, verify clipboard receives the value.
- [ ] Open the A11y panel on every new foundation story — confirm green.

## Follow-ups to file when this lands

- **SB-14b** — refactor button / input / textarea / dropdown / panel / copy-button / icon onto \`variants()\`; add \`panel({ shadow })\`; add \`input/textarea\` \`[aria-invalid]\` styling.