### PR TITLE
fix(storybook): guard staticDirs against missing design-showcase dir

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/html-vite';
 
 // Storybook 8 (HTML + Vite) configuration.
@@ -13,12 +16,17 @@ import type { StorybookConfig } from '@storybook/html-vite';
 // design system reads `[data-preset]` + `[data-density]`. Until SB-16 lands,
 // switching the toolbar produces minimal visual change.
 
+// Static dirs guarded by existsSync — `public/design-showcase/` is gitignored
+// (extracted from the IT Tools zip via `pnpm design:extract`); CI clones do
+// not have it. Storybook 8.6 hard-fails when a `staticDirs` path is missing,
+// so we conditionally include the path only when it actually exists.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DESIGN_SHOWCASE = resolve(HERE, '../public/design-showcase');
+const staticDirs: string[] = existsSync(DESIGN_SHOWCASE) ? ['../public/design-showcase'] : [];
+
 const config: StorybookConfig = {
   stories: ['../src/stories/**/*.stories.ts'],
-  // Narrow allowlist (SB-12 / #50). The live app's `public/` contains
-  // favicons, manifests, and SEO files that Storybook does not need; only
-  // `design-showcase/` is required by the iframe stories.
-  staticDirs: ['../public/design-showcase'],
+  staticDirs,
   framework: {
     name: '@storybook/html-vite',
     options: {},


### PR DESCRIPTION
## Summary

**Hotfix for the broken Day-A Pages deploy.** #71 merged green locally but the post-merge Pages deploy failed:

\`\`\`
Error: Failed to load static files, no such directory:
  /home/runner/work/developer-tools/developer-tools/public/design-showcase
Make sure this directory exists.
\`\`\`

**Root cause:** \`public/design-showcase/\` is gitignored (extracted from the IT Tools zip via \`pnpm design:extract\` — local-only). CI clones never have it. Storybook 8.6 hard-fails when a \`staticDirs\` path is missing.

**Fix:** wrap the \`staticDirs\` array in an \`existsSync\` check. The path is included only when the directory exists on disk. CI builds with an empty \`staticDirs\`; local dev keeps the design-showcase iframe stories working.

Refs #71 (broke), #50 (introduced the narrowed staticDirs).

## Verification

Locally simulated CI by renaming \`public/design-showcase/\` away and re-running:

\`\`\`
mv public/design-showcase /tmp/_backup
pnpm build-storybook   # exits 0 ✅ (was: Error: Failed to load static files)
mv /tmp/_backup public/design-showcase
\`\`\`

- \`pnpm typecheck\` — clean
- \`pnpm build-storybook\` — clean both with and without the dir

## Lesson saved to memory

\`feedback_storybook_static_dirs.md\` — guard any \`staticDirs\` path that might be gitignored or auto-generated.

## Test plan

- [ ] After merge, watch the \`Deploy to GitHub Pages\` workflow run on master and confirm it succeeds.
- [ ] Confirm \`https://pratiyush.github.io/developer-tools/storybook/\` returns HTTP 200.