### PR TITLE
feat(storybook): wire toolbar decorator (SB-03)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,43 +1,50 @@
 import type { Preview } from '@storybook/html';
+import { themeDecorator } from '../src/stories/_decorators/theme';
 
 const preview: Preview = {
+  decorators: [themeDecorator],
   globalTypes: {
     theme: {
-      description: 'Design theme from the extracted zip',
-      defaultValue: 'mono',
+      // Mirrors `THEMES` in `src/lib/theme.ts`. Default matches `DEFAULT_THEME`.
+      // Both `theme` and `preset` are written to `<html>` until SB-16 (#54)
+      // unifies on `[data-preset]` + `[data-density]`.
+      description: 'Live app theme — applied as [data-theme] on <html>',
+      defaultValue: 'clean',
       toolbar: {
         title: 'Theme',
         icon: 'paintbrush',
         items: [
-          { value: 'mono', title: 'Mono' },
-          { value: 'editorial', title: 'Editorial' },
-          { value: 'grid', title: 'Grid' },
-          { value: 'aurora', title: 'Aurora' },
           { value: 'clean', title: 'Clean' },
-        ],
-        dynamicTitle: true,
-      },
-    },
-    preset: {
-      description: 'Curated preset: theme + accent + type + radius',
-      defaultValue: 'linear',
-      toolbar: {
-        title: 'Preset',
-        icon: 'switchalt',
-        items: [
           { value: 'linear', title: 'Linear' },
           { value: 'vercel', title: 'Vercel' },
           { value: 'paper', title: 'Paper' },
           { value: 'swiss', title: 'Swiss' },
           { value: 'aurora', title: 'Aurora' },
+          { value: 'matrix', title: 'Matrix' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+    preset: {
+      description: 'Design preset — applied as [data-preset] on <html>',
+      defaultValue: 'clean',
+      toolbar: {
+        title: 'Preset',
+        icon: 'switchalt',
+        items: [
           { value: 'clean', title: 'Clean' },
+          { value: 'linear', title: 'Linear' },
+          { value: 'vercel', title: 'Vercel' },
+          { value: 'paper', title: 'Paper' },
+          { value: 'swiss', title: 'Swiss' },
+          { value: 'aurora', title: 'Aurora' },
           { value: 'matrix', title: 'Matrix' },
         ],
         dynamicTitle: true,
       },
     },
     density: {
-      description: 'Density scale',
+      description: 'Density scale — applied as [data-density] on <html>',
       defaultValue: 'default',
       toolbar: {
         title: 'Density',

--- a/src/stories/_decorators/theme.test.ts
+++ b/src/stories/_decorators/theme.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { applyThemeGlobals, themeDecorator } from './theme';
+
+describe('applyThemeGlobals', () => {
+  it('writes theme, preset, density to dataset', () => {
+    const root = document.createElement('div');
+    applyThemeGlobals({ theme: 'aurora', preset: 'aurora', density: 'compact' }, root);
+    expect(root.dataset.theme).toBe('aurora');
+    expect(root.dataset.preset).toBe('aurora');
+    expect(root.dataset.density).toBe('compact');
+  });
+
+  it('skips empty values without overwriting existing dataset attrs', () => {
+    const root = document.createElement('div');
+    root.dataset.theme = 'clean';
+    applyThemeGlobals({ theme: '', preset: 'linear' }, root);
+    expect(root.dataset.theme).toBe('clean');
+    expect(root.dataset.preset).toBe('linear');
+    expect(root.dataset.density).toBeUndefined();
+  });
+
+  it('skips undefined values', () => {
+    const root = document.createElement('div');
+    applyThemeGlobals({ theme: 'matrix' }, root);
+    expect(root.dataset.theme).toBe('matrix');
+    expect(root.dataset.preset).toBeUndefined();
+    expect(root.dataset.density).toBeUndefined();
+  });
+});
+
+describe('themeDecorator', () => {
+  it('applies globals to document.documentElement before invoking the story', () => {
+    let called = false;
+    const story = (): string => {
+      called = true;
+      return 'rendered';
+    };
+    const result = themeDecorator(story, {
+      globals: { theme: 'paper', preset: 'paper', density: 'default' },
+    });
+    expect(called).toBe(true);
+    expect(result).toBe('rendered');
+    expect(document.documentElement.dataset.theme).toBe('paper');
+    expect(document.documentElement.dataset.preset).toBe('paper');
+    expect(document.documentElement.dataset.density).toBe('default');
+  });
+
+  it('passes the context through to the wrapped story', () => {
+    const seen: string[] = [];
+    const story = (ctx: { globals: { theme?: string } }): null => {
+      if (ctx.globals.theme !== undefined) seen.push(ctx.globals.theme);
+      return null;
+    };
+    themeDecorator(story, { globals: { theme: 'swiss' } });
+    expect(seen).toEqual(['swiss']);
+  });
+});

--- a/src/stories/_decorators/theme.ts
+++ b/src/stories/_decorators/theme.ts
@@ -1,0 +1,54 @@
+/**
+ * Storybook decorator that writes the toolbar's theme / preset / density
+ * globals onto the document root so CSS rules keyed on `[data-theme]`,
+ * `[data-preset]`, `[data-density]` actually apply.
+ *
+ * Storybook's HTML framework calls the decorator with `(storyFn, context)`;
+ * we only read `context.globals`. The decorator returns the rendered DOM
+ * unchanged.
+ *
+ * SB-16 (#54) folds `[data-theme]` into `[data-preset]` later. Until then,
+ * both attributes are written so the live app's CSS (which still keys on
+ * `[data-theme]`) and the design system's CSS (`[data-preset]`/`[data-density]`)
+ * both repaint together.
+ */
+
+interface ThemeGlobals {
+  readonly theme?: string;
+  readonly preset?: string;
+  readonly density?: string;
+}
+
+/**
+ * Apply the toolbar globals to a root element. Exported separately from the
+ * Storybook-shaped decorator so unit tests can drive it without pulling in
+ * Storybook's runtime.
+ */
+export function applyThemeGlobals(globals: ThemeGlobals, root: HTMLElement): void {
+  if (typeof globals.theme === 'string' && globals.theme.length > 0) {
+    root.dataset.theme = globals.theme;
+  }
+  if (typeof globals.preset === 'string' && globals.preset.length > 0) {
+    root.dataset.preset = globals.preset;
+  }
+  if (typeof globals.density === 'string' && globals.density.length > 0) {
+    root.dataset.density = globals.density;
+  }
+}
+
+interface DecoratorContext {
+  readonly globals: ThemeGlobals;
+}
+
+type StoryFn = (context: DecoratorContext) => unknown;
+
+/**
+ * Storybook HTML decorator. Reads `context.globals` and applies them to
+ * `document.documentElement` before delegating to the wrapped story.
+ */
+export function themeDecorator(storyFn: StoryFn, context: DecoratorContext): unknown {
+  if (typeof document !== 'undefined') {
+    applyThemeGlobals(context.globals, document.documentElement);
+  }
+  return storyFn(context);
+}


### PR DESCRIPTION
## Summary

Wires the Storybook toolbar globals (theme / preset / density) onto the document root so switching them actually changes how stories render.

(Replaces #72 which auto-closed when its base branch was merged. Same code, rebased onto current master.)

Closes #42 (SB-03). Refs #70 (Storybook-first, live-app-after policy).

## What changed

- New \`src/stories/_decorators/theme.ts\` — \`themeDecorator\` (Storybook-shaped) + \`applyThemeGlobals\` (testable inner). Both write \`data-theme\`, \`data-preset\`, \`data-density\` to the document root.
- \`.storybook/preview.ts\` decorators array now applies the decorator on every render.
- Replaced design-only theme list (\`mono / editorial / grid / aurora / clean\`) with the live app's 7 themes from \`src/lib/theme.ts\` (\`clean / linear / vercel / paper / swiss / aurora / matrix\`). Default switched from invalid \`mono\` to \`clean\`.
- Both \`[data-theme]\` and \`[data-preset]\` written until #54 (SB-16) unifies on \`[data-preset]\` + \`[data-density]\`.

## Tests

5 new vitest cases covering applyThemeGlobals + themeDecorator (dataset writes, empty-value skipping, undefined-value skipping, decorator invocation, context pass-through).

## Acceptance criteria (EARS)

- [x] **R5.1** — Toggling theme/preset/density visibly changes the active story.
- [x] **R5.2** — Globals persist across navigation.
- [ ] R5.3 / R5.4 — addon-a11y delivered separately (next stacked PR).

## Verification

- \`pnpm typecheck\` — clean
- \`pnpm test\` — passes (537+ tests)
- \`pnpm lint\` — 0 errors
- \`pnpm build-storybook\` — clean
- \`pnpm build\` — live app builds

## Test plan

- [ ] After merge, watch the \`Deploy to GitHub Pages\` workflow on master.
- [ ] Open \`https://pratiyush.github.io/developer-tools/storybook/\` → switch theme dropdown across all 7 values → confirm \`<html data-theme="...">\` updates and visible style changes apply.