### PR TITLE
feat(storybook): locale toolbar (15 locales) + RTL (SB-07)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,8 +1,20 @@
 import type { Preview } from '@storybook/html';
 import { themeDecorator } from '../src/stories/_decorators/theme';
+import { localeDecorator } from '../src/stories/_decorators/locale';
+import { LOCALES } from '../src/locales';
+
+// Locale toolbar items derived from the live app's `LOCALES` so the source
+// of truth stays in one place. The default matches the live app's
+// browser-language detection: `navigator.language?.slice(0, 2)` is used at
+// build-time, falling back to `en` if the locale isn't recognized.
+const detectDefaultLocale = (): string => {
+  if (typeof navigator === 'undefined') return 'en';
+  const code = navigator.language.slice(0, 2);
+  return LOCALES.some((l) => l.code === code) ? code : 'en';
+};
 
 const preview: Preview = {
-  decorators: [themeDecorator],
+  decorators: [themeDecorator, localeDecorator],
   globalTypes: {
     theme: {
       // Mirrors `THEMES` in `src/lib/theme.ts`. Default matches `DEFAULT_THEME`.
@@ -53,6 +65,22 @@ const preview: Preview = {
           { value: 'default', title: 'Default' },
           { value: 'compact', title: 'Compact' },
         ],
+        dynamicTitle: true,
+      },
+    },
+    // SB-07 (#46): all 15 locales the live app supports. Items derive from
+    // `LOCALES` in src/locales/index.ts. Selecting `ar` flips `<html dir>`
+    // to `rtl` via the `localeDecorator`.
+    locale: {
+      description: 'i18n locale — wired through the live-app provider',
+      defaultValue: detectDefaultLocale(),
+      toolbar: {
+        title: 'Locale',
+        icon: 'globe',
+        items: LOCALES.map((l) => ({
+          value: l.code,
+          title: `${l.nativeLabel} (${l.code}${l.dir === 'rtl' ? ', RTL' : ''})`,
+        })),
         dynamicTitle: true,
       },
     },

--- a/src/stories/00-foundations/rtl.stories.ts
+++ b/src/stories/00-foundations/rtl.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/html';
+import '../_styles/foundations.css';
+import { segment } from '../../ui/primitives/segment';
+import { status } from '../../ui/primitives/status';
+import { stat, statGrid } from '../../ui/primitives/stat';
+import { kvList } from '../../ui/data-display/kv-list';
+
+// SB-07 (#46): RTL baseline. Each story exercises the SB-14 primitives
+// inside an explicit RTL container so the visual matrix has a deterministic
+// snapshot. The locale toolbar (default `ar`) also flips `<html dir>` for
+// the surrounding chrome — these stories use a nested `dir="rtl"` so the
+// snapshot is stable even when run under LTR locales.
+
+const meta: Meta = {
+  title: 'Foundations / RTL',
+};
+
+export default meta;
+
+function rtlHost(child: HTMLElement): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'dt-foundation-host';
+  root.setAttribute('dir', 'rtl');
+  root.style.padding = '24px';
+  root.style.maxWidth = '720px';
+  root.appendChild(child);
+  return root;
+}
+
+export const SegmentRtl: StoryObj = {
+  name: 'Segment / RTL',
+  render: () =>
+    rtlHost(segment({ items: ['الكل', 'مرشح', 'مرتب'], selected: 0, ariaLabel: 'تصفية' })),
+};
+
+export const StatusRtl: StoryObj = {
+  name: 'Status / RTL',
+  render: () => {
+    const wrap = document.createElement('div');
+    wrap.style.display = 'flex';
+    wrap.style.gap = '12px';
+    wrap.style.flexWrap = 'wrap';
+    wrap.appendChild(status({ label: 'نشط', tone: 'success' }));
+    wrap.appendChild(status({ label: 'خطأ', tone: 'danger' }));
+    wrap.appendChild(status({ label: 'تحذير', tone: 'warning' }));
+    return rtlHost(wrap);
+  },
+};
+
+export const StatGridRtl: StoryObj = {
+  name: 'Stat grid / RTL',
+  render: () =>
+    rtlHost(
+      statGrid({
+        stats: [
+          { label: 'الأدوات', value: '42', delta: '+3', deltaPositive: true },
+          { label: 'الأخطاء', value: '7', delta: '-2', deltaPositive: false },
+          { label: 'اللغات', value: '15' },
+        ],
+      }),
+    ),
+};
+
+export const KvListRtl: StoryObj = {
+  name: 'KV list / RTL',
+  render: () =>
+    rtlHost(
+      kvList({
+        entries: [
+          { key: 'المعرف', value: '123', mono: true, copyable: true },
+          { key: 'الاسم', value: 'محول قاعدة 64', copyable: true },
+          { key: 'الحالة', value: 'نشط' },
+        ],
+      }).el,
+    ),
+};
+
+// Keep `stat` in the import graph (single-card variant cheap to render).
+export const StatSingleRtl: StoryObj = {
+  name: 'Stat / RTL',
+  render: () => rtlHost(stat({ label: 'إجمالي', value: '532' })),
+};

--- a/src/stories/_decorators/locale.test.ts
+++ b/src/stories/_decorators/locale.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { applyLocale, localeDecorator } from './locale';
+
+vi.mock('../../lib/i18n', () => ({
+  setLocale: vi.fn(),
+}));
+
+const { setLocale: mockedSetLocale } = await import('../../lib/i18n');
+
+afterEach(() => {
+  vi.mocked(mockedSetLocale).mockClear();
+});
+
+describe('applyLocale', () => {
+  it('sets lang + dir on the root for a known LTR locale', () => {
+    const root = document.createElement('div');
+    applyLocale({ locale: 'ja' }, root);
+    expect(root.getAttribute('lang')).toBe('ja');
+    expect(root.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('sets dir=rtl for Arabic', () => {
+    const root = document.createElement('div');
+    applyLocale({ locale: 'ar' }, root);
+    expect(root.getAttribute('lang')).toBe('ar');
+    expect(root.getAttribute('dir')).toBe('rtl');
+  });
+
+  it('ignores unknown locale codes', () => {
+    const root = document.createElement('div');
+    applyLocale({ locale: 'xx' }, root);
+    expect(root.hasAttribute('lang')).toBe(false);
+    expect(root.hasAttribute('dir')).toBe(false);
+  });
+
+  it('skips when locale is missing', () => {
+    const root = document.createElement('div');
+    applyLocale({}, root);
+    expect(root.hasAttribute('lang')).toBe(false);
+  });
+
+  it('calls setLocale on the in-app provider', () => {
+    const root = document.createElement('div');
+    applyLocale({ locale: 'de' }, root);
+    expect(mockedSetLocale).toHaveBeenCalledWith('de', false);
+  });
+});
+
+describe('localeDecorator', () => {
+  it('applies the locale to documentElement and forwards to the story', () => {
+    const seen: string[] = [];
+    const story = (ctx: { globals: { locale?: string } }): null => {
+      if (ctx.globals.locale !== undefined) seen.push(ctx.globals.locale);
+      return null;
+    };
+    localeDecorator(story, { globals: { locale: 'fr' } });
+    expect(document.documentElement.getAttribute('lang')).toBe('fr');
+    expect(document.documentElement.getAttribute('dir')).toBe('ltr');
+    expect(seen).toEqual(['fr']);
+  });
+});

--- a/src/stories/_decorators/locale.ts
+++ b/src/stories/_decorators/locale.ts
@@ -1,0 +1,47 @@
+/**
+ * Storybook decorator that consumes the toolbar's `locale` global and:
+ *   1. Calls `setLocale()` on the live app's i18n provider so stories that
+ *      use `translate(key)` re-render with the chosen locale.
+ *   2. Writes `<html lang="…">` for assistive tech.
+ *   3. Writes `<html dir="rtl|ltr">` based on the locale's declared
+ *      direction (only `ar` flips today; we still reset `ltr` on every
+ *      non-RTL render so a previous RTL story can't bleed in).
+ *
+ * Like the theme decorator (SB-03 / #42), the inner `applyLocale`
+ * function is exported separately so it can be unit-tested without
+ * Storybook's runtime.
+ */
+
+import { getDir, isLocale, type LocaleCode } from '../../locales';
+import { setLocale } from '../../lib/i18n';
+
+interface LocaleGlobals {
+  readonly locale?: string;
+}
+
+interface DecoratorContext {
+  readonly globals: LocaleGlobals;
+}
+
+type StoryFn = (context: DecoratorContext) => unknown;
+
+/**
+ * Pure inner: apply the chosen locale to the provided root element +
+ * the in-app provider. Skips when the locale is empty / unknown to
+ * avoid clobbering the existing state during initial render.
+ */
+export function applyLocale(globals: LocaleGlobals, root: HTMLElement): void {
+  const raw = globals.locale;
+  if (typeof raw !== 'string' || raw.length === 0 || !isLocale(raw)) return;
+  const locale: LocaleCode = raw;
+  setLocale(locale, false);
+  root.setAttribute('lang', locale);
+  root.setAttribute('dir', getDir(locale));
+}
+
+export function localeDecorator(storyFn: StoryFn, context: DecoratorContext): unknown {
+  if (typeof document !== 'undefined') {
+    applyLocale(context.globals, document.documentElement);
+  }
+  return storyFn(context);
+}


### PR DESCRIPTION
## Summary

Wires the Storybook toolbar's `locale` global into the live app's i18n provider. 15 locales (derived from `LOCALES`), default = `navigator.language` with `en` fallback, `dir="rtl"` for `ar`.

Closes #46.

## Changes

- **New** `src/stories/_decorators/locale.ts` — `applyLocale` (testable) + `localeDecorator` (Storybook). Calls `setLocale`, writes `<html lang>` + `<html dir>`.
- **`.storybook/preview.ts`** — `locale` global with items derived from `LOCALES`; decorator wired.
- **New** `src/stories/00-foundations/rtl.stories.ts` — RTL baseline using SB-14 primitives in explicit `dir="rtl"` containers.

## Verification

- typecheck ✅
- 594 tests (6 new) ✅
- lint 0 errors ✅
- build-storybook ✅

## Test plan

- [ ] After merge, verify Pages deploy succeeds.
- [ ] Open Storybook → switch locale dropdown to `ar` → confirm `<html dir="rtl">` flips and the new RTL foundation stories render mirrored.